### PR TITLE
Deprecate special props where generic ones will do

### DIFF
--- a/asgs-id.ttl
+++ b/asgs-id.ttl
@@ -22,25 +22,25 @@ asgs:AustralianDrainageDivision
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:addName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:addName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:addCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:addCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:DestinationZone
@@ -48,19 +48,19 @@ asgs:DestinationZone
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:dzn5dig11 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:dznCode11 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:dznCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:GreaterCapitalCityStatisticalArea
@@ -68,31 +68,31 @@ asgs:GreaterCapitalCityStatisticalArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:gccsaName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:gccsaName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:gccsaCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:gccsaCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:greaterCapitalCityStatisticalAreasGccsa5CharacterAlphanumericCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:IndigenousArea
@@ -100,31 +100,31 @@ asgs:IndigenousArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:iareName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:iareName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:iareCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:iareCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:indigenousAreas6DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:IndigenousLocation
@@ -132,25 +132,25 @@ asgs:IndigenousLocation
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:ilocName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:ilocName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:ilocCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:ilocCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:IndigenousRegion
@@ -158,31 +158,31 @@ asgs:IndigenousRegion
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:iregName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:iregName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:indigenousRegions3DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:iregCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:iregCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:LocalGovernmentArea
@@ -190,13 +190,13 @@ asgs:LocalGovernmentArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:lgaName2012 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:lgaCode2012 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:MeshBlock
@@ -204,13 +204,13 @@ asgs:MeshBlock
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:mbCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:mbCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:NaturalResourceManagementRegion
@@ -218,25 +218,25 @@ asgs:NaturalResourceManagementRegion
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:nrmrName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:nrmrName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:nrmrCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:nrmrCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:PostalArea
@@ -244,25 +244,25 @@ asgs:PostalArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:poaName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:poaName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:poaCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:poaCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:RemotenessArea
@@ -270,25 +270,25 @@ asgs:RemotenessArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:raName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:raName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:raCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:raCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:SectionOfState
@@ -296,31 +296,31 @@ asgs:SectionOfState
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sosName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sosName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sectionOfState2DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sosCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sosCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:SectionOfStateRange
@@ -328,31 +328,31 @@ asgs:SectionOfStateRange
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sosrName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sosrName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sectionOfStateRange3DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sosrCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sosrCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:SignificantUrbanArea
@@ -360,25 +360,25 @@ asgs:SignificantUrbanArea
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:suaName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:suaName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:suaCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:suaCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StateElectoralDivision
@@ -386,19 +386,19 @@ asgs:StateElectoralDivision
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:stateelectoraldivisionIdentifier ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sedCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sedCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StateOrTerritory
@@ -406,31 +406,31 @@ asgs:StateOrTerritory
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:stateName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:stateName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:stateCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:stateCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:stateOrTerritory1DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StatisticalAreaLevel1
@@ -438,19 +438,19 @@ asgs:StatisticalAreaLevel1
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa1Maincode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa1Maincode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:statisticalArea1Sa111DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StatisticalAreaLevel2
@@ -458,31 +458,31 @@ asgs:StatisticalAreaLevel2
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa2Name2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa2Name2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa2Maincode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa2Maincode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:statisticalArea2Sa29DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StatisticalAreaLevel3
@@ -490,31 +490,31 @@ asgs:StatisticalAreaLevel3
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa3Name2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa3Name2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa3Code2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa3Code2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:statisticalArea3Sa35DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:StatisticalAreaLevel4
@@ -522,31 +522,31 @@ asgs:StatisticalAreaLevel4
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa4Name2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:sa4Name2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa4Code2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:sa4Code2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:statisticalArea4Sa43DigitCode ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:TourismRegion
@@ -554,13 +554,13 @@ asgs:TourismRegion
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:trCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:trCode2012 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 asgs:UrbanCentreAndLocality
@@ -568,25 +568,25 @@ asgs:UrbanCentreAndLocality
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:uclName2011 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onClass asgs-id:uclName2016 ;
-      owl:onProperty asgs:label ;
+      owl:onProperty rdfs:label ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:uclCode2011 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onDataRange asgs-id:uclCode2016 ;
-      owl:onProperty asgs:code ;
+      owl:onProperty dcterms:identifier ;
     ] ;
 .
 <http://linked.data.gov.au/def/asgs-id>

--- a/asgs-prop.ttl
+++ b/asgs-prop.ttl
@@ -1,0 +1,69 @@
+# baseURI: http://linked.data.gov.au/def/asgs-prop
+# imports: http://linked.data.gov.au/def/asgs
+# prefix: asgs-prop
+
+@prefix asgs: <http://linked.data.gov.au/def/asgs#> .
+@prefix asgs-prop: <http://linked.data.gov.au/def/asgs-prop#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+asgs:category
+  a owl:ObjectProperty ;
+  rdfs:domain asgs:MeshBlock ;
+  rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
+  rdfs:label "category" ;
+  rdfs:range asgs:MeshblockCategory ;
+  rdfs:seeAlso asgs:MeshBlock ;
+  rdfs:subPropertyOf dcterms:type ;
+.
+asgs:code
+  a owl:DatatypeProperty ;
+  rdfs:domain asgs:Feature ;
+  rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
+  rdfs:label "code" ;
+  rdfs:range xsd:string ;
+  rdfs:seeAlso asgs:Feature ;
+  rdfs:subPropertyOf dcterms:identifier ;
+.
+asgs:contains
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
+  rdfs:label "contains" ;
+  rdfs:seeAlso asgs:Feature ;
+  rdfs:subPropertyOf geo:sfContains ;
+.
+asgs:label
+  a owl:AnnotationProperty ;
+  a owl:DatatypeProperty ;
+  rdfs:domain asgs:Feature ;
+  rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
+  rdfs:label "label" ;
+  rdfs:range xsd:string ;
+  rdfs:seeAlso asgs:Feature ;
+  rdfs:subPropertyOf rdfs:label ;
+.
+asgs:within
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
+  rdfs:label "is within" ;
+  rdfs:seeAlso asgs:Feature ;
+  rdfs:subPropertyOf geo:sfWithin ;
+.
+<http://linked.data.gov.au/def/asgs-prop>
+  a owl:Ontology ;
+  dcterms:created "2020-02-03" ;
+  dcterms:creator "<a href='https://orcid.org/0000-0002-3884-3420'>Simon J D Cox, CSIRO</a>"^^rdf:HTML ;
+  dcterms:description """<p>Australian Statistical Geography Standard (ASGS) ABS Structures and non-ABS structures</p>
+                    <p>Ontology for the Australian Statistical Geography Standard (ASGS), a framework of statistical areas used by the Australian Bureau of Statistics (ABS) and other organisations to enable the publication of statistics that are comparable and spatially integrated. This ontology contains the definitions for the ABS Structures which are areas that the ABS designs specifically for outputting statistics.</p>
+					<p>Specialized properties which shadow ones from standard RDF vocabularies</p>"""^^rdf:HTML ;
+  dcterms:modified "2020-02-03" ;
+  dcterms:publisher "<a href='http://catalogue.linked.data.gov.au/org/O-000928'>Australian Bureau of Statistics</a>"^^rdf:HTML ;
+  dcterms:rights "Copyright 2020 Australian Bureau of Statistics." ;
+  dcterms:title "ASGS Ontology - specialized properties" ;
+  owl:deprecated true ;
+  owl:imports <http://linked.data.gov.au/def/asgs> ;
+.

--- a/asgs.diagrams
+++ b/asgs.diagrams
@@ -11,12 +11,26 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >296</cd:width>
+        >881</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >153</cd:y>
+        >528</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >538</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
+        >66</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1"/>
+      </cd:URINode>
+    </cd:nodes>
+    <rdfs:label>asgs:Feature Diagram</rdfs:label>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >444</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >240</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >132</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1365</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -24,12 +38,26 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >360</cd:width>
+        >572</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >329</cd:y>
+        >239</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >338</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3"/>
+        >247</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >92</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >190</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >472</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1051</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -50,12 +78,12 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >572</cd:width>
+        >360</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >239</cd:y>
+        >329</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >247</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4"/>
+        >338</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -76,51 +104,12 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >881</cd:width>
+        >296</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >528</cd:y>
+        >153</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >66</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >444</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >240</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >132</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1365</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >92</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >190</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >472</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1051</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >60</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >360</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >606</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >965</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
+        >538</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -149,8 +138,19 @@
         <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
       </cd:URINode>
     </cd:nodes>
-    <rdfs:label>asgs:Feature Diagram</rdfs:label>
-    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >60</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >360</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >606</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >965</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
+      </cd:URINode>
+    </cd:nodes>
   </cd:Diagram>
   <cd:Diagram>
     <cd:nodes>
@@ -158,25 +158,38 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >124</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >370</cd:width>
+        >305</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >207</cd:y>
+        >458</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >74</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
+        >148</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#IndigenousArea"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >588</cd:height>
+        >76</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >364</cd:width>
+        >190</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >96</cd:y>
+        >465</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >855</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
+        >582</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >60</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >241</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >315</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >551</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Feature"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -195,41 +208,14 @@
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >76</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >170</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >603</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >592</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >76</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >190</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >465</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >582</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >124</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >305</cd:width>
+        >370</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >458</cd:y>
+        >207</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >148</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#IndigenousArea"/>
+        >74</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -248,14 +234,14 @@
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >60</cd:height>
+        >588</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >241</cd:width>
+        >364</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >315</cd:y>
+        >96</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >551</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Feature"/>
+        >855</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
       </cd:URINode>
     </cd:nodes>
     <rdfs:label>asgs:LocalGovernmentArea Diagram</rdfs:label>
@@ -270,6 +256,20 @@
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >264</cd:x>
         <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Country"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >76</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >170</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >603</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >592</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
       </cd:URINode>
     </cd:nodes>
   </cd:Diagram>

--- a/asgs.diagrams
+++ b/asgs.diagrams
@@ -9,174 +9,27 @@
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >124</cd:height>
+        >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >370</cd:width>
+        >296</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >207</cd:y>
+        >153</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >74</cd:x>
+        >538</cd:x>
         <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >76</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >170</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >603</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >592</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
-      </cd:URINode>
-    </cd:nodes>
-    <rdfs:label>asgs:LocalGovernmentArea Diagram</rdfs:label>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >60</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >207</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >369</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >211</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >76</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >190</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >465</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >582</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >588</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >364</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >96</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >855</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >124</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >305</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >458</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >148</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#IndigenousArea"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >156</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >218</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >102</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >567</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >60</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >241</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >315</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >551</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Feature"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >60</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >170</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >103</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >264</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Country"/>
-      </cd:URINode>
-    </cd:nodes>
-  </cd:Diagram>
-  <cd:Diagram>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >881</cd:width>
+        >360</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >528</cd:y>
+        >329</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >66</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >92</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >190</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >472</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1051</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >36</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >122</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >84</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >786</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Country"/>
-      </cd:URINode>
-    </cd:nodes>
-    <cd:nodes>
-      <cd:URINode>
-        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >444</cd:height>
-        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >240</cd:width>
-        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >132</cd:y>
-        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >1365</cd:x>
-        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
+        >338</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -197,26 +50,64 @@
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >360</cd:width>
+        >572</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >329</cd:y>
+        >239</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >338</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel3"/>
+        >247</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4"/>
       </cd:URINode>
     </cd:nodes>
-    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >36</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >122</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >84</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >786</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Country"/>
+      </cd:URINode>
+    </cd:nodes>
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
         >44</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >296</cd:width>
+        >881</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >153</cd:y>
+        >528</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >538</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
+        >66</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel1"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >444</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >240</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >132</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1365</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >92</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >190</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >472</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >1051</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
       </cd:URINode>
     </cd:nodes>
     <cd:nodes>
@@ -258,19 +149,128 @@
         <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
       </cd:URINode>
     </cd:nodes>
+    <rdfs:label>asgs:Feature Diagram</rdfs:label>
+    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+  </cd:Diagram>
+  <cd:Diagram>
     <cd:nodes>
       <cd:URINode>
         <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >44</cd:height>
+        >124</cd:height>
         <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >572</cd:width>
+        >370</cd:width>
         <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >239</cd:y>
+        >207</cd:y>
         <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
-        >247</cd:x>
-        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StatisticalAreaLevel4"/>
+        >74</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#StateOrTerritory"/>
       </cd:URINode>
     </cd:nodes>
-    <rdfs:label>asgs:Feature Diagram</rdfs:label>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >588</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >364</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >96</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >855</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#SpatialObject"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >156</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >218</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >102</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >567</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >76</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >170</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >603</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >592</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#MeshBlock"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >76</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >190</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >465</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >582</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Feature"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:selectedResource rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >124</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >305</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >458</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >148</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#IndigenousArea"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >60</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >207</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >369</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >211</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#LocalGovernmentArea"/>
+      </cd:URINode>
+    </cd:nodes>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >60</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >241</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >315</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >551</cd:x>
+        <cd:class rdf:resource="http://www.opengis.net/ont/geosparql#Feature"/>
+      </cd:URINode>
+    </cd:nodes>
+    <rdfs:label>asgs:LocalGovernmentArea Diagram</rdfs:label>
+    <cd:nodes>
+      <cd:URINode>
+        <cd:height rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >60</cd:height>
+        <cd:width rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >170</cd:width>
+        <cd:y rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >103</cd:y>
+        <cd:x rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+        >264</cd:x>
+        <cd:class rdf:resource="http://linked.data.gov.au/def/asgs#Country"/>
+      </cd:URINode>
+    </cd:nodes>
   </cd:Diagram>
 </rdf:RDF>

--- a/asgs.html
+++ b/asgs.html
@@ -174,7 +174,7 @@ code {
     ],
     "https://schema.org/description": [
       {
-        "@value": "<p><a href=\"https://www.abs.gov.au/websitedbs/D3310114.nsf/home/Australian+Statistical+Geography+Standard+(ASGS)\">Australian Statistical Geography Standard (ASGS)</a> ABS Structures and non-ABS structures</p>\n\n<p>Ontology for the Australian Statistical Geography Standard (ASGS), a framework of statistical areas used by the Australian Bureau of Statistics (ABS) and other organisations to enable the publication of statistics that are comparable and spatially integrated. This ontology contains the definitions for the ABS Structures which are areas that the ABS designs specifically for outputting statistics.</p>\n\n<ul>\n  <li>structures: Mesh Block, Statistical Areas (Level 1 to Level 4), Greater Capital City Statistical Areas, State or Territory, Country classes,</li> \n  <li>Indigenous structures: Indigenous location, Indigenous area, , Indigenous region classes</li>\n  <li>Urban structures: Urban Centre and Locality, Section of State Range, Section of State, and Significant Urban Area classes</li>\n</ul>\n\n<p>and for the Non ABS Structures which are not defined or maintained by the ABS but represent administrative areas for which the ABS is committed to providing a range of statistics. The classes defined here corresponds to ABS approximations of spatial areas or regions which are defined elsewhere</p>\n\n<ul>   \n  <li>Local Government Areas (LGAs)</li>\n  <li>Postal Areas (POAs)</li>\n  <li>State Suburbs (SSCs)</li>\n  <li>Commonwealth Electoral Divisions (CEDs)</li>\n  <li>State Electoral Divisions (SEDs)</li>\n  <li>Australian Drainage Divisions (ADDs)</li>\n  <li>Natural Resource Management Regions (NRMRs)</li>\n  <li>Tourism Regions (TRs)</li>\n</ul>\n\n<p>The ASGS uses Mesh Blocks as a common building block for all structures. Mesh Blocks are small enough that they can accurately approximate the changing administrative areas maintained by other organisations, without changing themselves.</p>\n\n<p><p>The publication of the ASGS ontology is part of the Australian Bureau of Statistics contribution to a joint effort to publish authoritative, interconnected spatial products (Location Index project).</p>\n<p>The ASGS Ontology is packaged in multiple graphs:</p>\n<ul>\n    <li>http://linked.data.gov.au/def/asgs (this graph) contains the core classes for ASGS statistical units, and a small number of properties relating to their identity, classification, and containment hierarchy</li>\n  <li>http://linked.data.gov.au/def/asgs-cat contains the meshblock classification scheme</li>\n  <li>http://linked.data.gov.au/def/asgs-id contains specialised string types for identifiers and labels</li>\n  <li>http://linked.data.gov.au/def/asgs-path contains association classes and properties relating to paths between instances of the core classes</li>\n  <li>http://linked.data.gov.au/def/asgs-isof (deprecated) contains specialized predicates for containment relationships - this functionality is provided by the generic 'within' and 'contains' relations</li>\n  <li>http://linked.data.gov.au/def/asgs-code (deprecated) contains specialised annotation properties for identifiers and labels - this functionality has been superseded by a set of data-types to be used in conjunction with more generic properties</li>\n</u></p>"
+        "@value": "<p><a href='https://www.abs.gov.au/websitedbs/D3310114.nsf/home/Australian+Statistical+Geography+Standard+(ASGS)'>Australian Statistical Geography Standard (ASGS)</a> ABS Structures and non-ABS structures</p>\n\n<p>Ontology for the Australian Statistical Geography Standard (ASGS), a framework of statistical areas used by the Australian Bureau of Statistics (ABS) and other organisations to enable the publication of statistics that are comparable and spatially integrated. This ontology contains the definitions for the ABS Structures which are areas that the ABS designs specifically for outputting statistics.</p>\n\n<ul>\n  <li>structures: Mesh Block, Statistical Areas (Level 1 to Level 4), Greater Capital City Statistical Areas, State or Territory, Country classes,</li> \n  <li>Indigenous structures: Indigenous location, Indigenous area, , Indigenous region classes</li>\n  <li>Urban structures: Urban Centre and Locality, Section of State Range, Section of State, and Significant Urban Area classes</li>\n</ul>\n\n<p>and for the Non ABS Structures which are not defined or maintained by the ABS but represent administrative areas for which the ABS is committed to providing a range of statistics. The classes defined here corresponds to ABS approximations of spatial areas or regions which are defined elsewhere</p>\n\n<ul>   \n  <li>Local Government Areas (LGAs)</li>\n  <li>Postal Areas (POAs)</li>\n  <li>State Suburbs (SSCs)</li>\n  <li>Commonwealth Electoral Divisions (CEDs)</li>\n  <li>State Electoral Divisions (SEDs)</li>\n  <li>Australian Drainage Divisions (ADDs)</li>\n  <li>Natural Resource Management Regions (NRMRs)</li>\n  <li>Tourism Regions (TRs)</li>\n</ul>\n\n<p>The ASGS uses Mesh Blocks as a common building block for all structures. Mesh Blocks are small enough that they can accurately approximate the changing administrative areas maintained by other organisations, without changing themselves.</p>\n\n<p><p>The publication of the ASGS ontology is part of the Australian Bureau of Statistics contribution to a joint effort to publish authoritative, interconnected spatial products (Location Index project).</p>\n<p>The ASGS Ontology is packaged in multiple graphs:</p>\n<ul>\n    <li>http://linked.data.gov.au/def/asgs (this graph) contains the core classes for ASGS statistical units, and a small number of properties relating to their identity, classification, and containment hierarchy</li>\n  <li>http://linked.data.gov.au/def/asgs-cat contains the meshblock classification scheme</li>\n  <li>http://linked.data.gov.au/def/asgs-id contains specialised string types for identifiers and labels</li>\n  <li>http://linked.data.gov.au/def/asgs-path contains association classes and properties relating to paths between instances of the core classes</li>\n  <li>http://linked.data.gov.au/def/asgs-isof (deprecated) contains specialized predicates for containment relationships - this functionality is provided by the generic 'within' and 'contains' relations</li>\n  <li>http://linked.data.gov.au/def/asgs-code (deprecated) contains specialised annotation properties for identifiers and labels - this functionality has been superseded by a set of data-types to be used in conjunction with more generic properties</li>\n  <li>http://linked.data.gov.au/def/asgs-prop (deprecated) contains specialised ASGS properties for relationships, classifiers, identifiers and labels - this functionality has been superseded by use of types from standardized RDF vocabularies</li>\n</u></p>"
       }
     ],
     "https://schema.org/name": [
@@ -193,7 +193,6 @@ code {
 </head>
 <body>
 <div id="pylode">made by <a href="http://github.com/rdflib/pyLODE">pyLODE</a></div>
-<img src="./images/ABS_Logo_333.svg" style="width:200px;" alt="ABS Logo" /><br />
 <h1>ASGS Ontology</h1>
 <section id="metadata">
     <h2 style="display:none;">Metadata</h2>
@@ -216,7 +215,7 @@ code {
         <dt>Created</dt>
         <dd>2018-11-23</dd>
         <dt>Modified</dt>
-        <dd>2020-01-14</dd>
+        <dd>2020-02-03</dd>
         <dt>Imports</dt>
         <dd>
             <a href="http://www.opengis.net/ont/geosparql">http://www.opengis.net/ont/geosparql</a><br/>
@@ -228,7 +227,7 @@ code {
     </dl>
     <h2>Description</h2>
     <div id="description">
-        <p><a href="https://www.abs.gov.au/websitedbs/D3310114.nsf/home/Australian+Statistical+Geography+Standard+(ASGS)">Australian Statistical Geography Standard (ASGS)</a> ABS Structures and non-ABS structures</p>
+        <p><a href='https://www.abs.gov.au/websitedbs/D3310114.nsf/home/Australian+Statistical+Geography+Standard+(ASGS)'>Australian Statistical Geography Standard (ASGS)</a> ABS Structures and non-ABS structures</p>
 
 <p>Ontology for the Australian Statistical Geography Standard (ASGS), a framework of statistical areas used by the Australian Bureau of Statistics (ABS) and other organisations to enable the publication of statistics that are comparable and spatially integrated. This ontology contains the definitions for the ABS Structures which are areas that the ABS designs specifically for outputting statistics.</p>
 
@@ -262,6 +261,7 @@ code {
   <li>http://linked.data.gov.au/def/asgs-path contains association classes and properties relating to paths between instances of the core classes</li>
   <li>http://linked.data.gov.au/def/asgs-isof (deprecated) contains specialized predicates for containment relationships - this functionality is provided by the generic 'within' and 'contains' relations</li>
   <li>http://linked.data.gov.au/def/asgs-code (deprecated) contains specialised annotation properties for identifiers and labels - this functionality has been superseded by a set of data-types to be used in conjunction with more generic properties</li>
+  <li>http://linked.data.gov.au/def/asgs-prop (deprecated) contains specialised ASGS properties for relationships, classifiers, identifiers and labels - this functionality has been superseded by use of types from standardized RDF vocabularies</li>
 </u></p>
     </div>
 </section>
@@ -279,7 +279,7 @@ code {
 <section id="overview">
     <h2>Overview</h2>
     <div class="figure">
-        <div style="width:500px; height:500px; background-color: black;"><img src="./images/asgs-Statistical-Areas.png"/></div>
+        <div style="width:500px; height:500px; background-color: black;">&nbsp;</div>
         <div class="caption"><strong>Figure 1:</strong> Ontology overview</div>
     </div>
 </section>
@@ -336,7 +336,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -363,8 +363,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -412,8 +412,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -434,45 +434,38 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">only</span> <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">only</span> <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">only</span> <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">only</span> <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
             <tr>
                 <th>Sub-classes</th>
                 <td>
-                    <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#DestinationZone">asgs:DestinationZone</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#StatisticalAreaLevel3">asgs:StatisticalAreaLevel3</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#SectionofStateRange">asgs:SectionOfStateRange</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#AustralianDrainageDivision">asgs:AustralianDrainageDivision</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#StatisticalAreaLevel4">asgs:StatisticalAreaLevel4</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#TourismRegion">asgs:TourismRegion</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#RemotenessArea">asgs:RemotenessArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#Country">asgs:Country</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#Postalarea">asgs:PostalArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#SectionofState">asgs:SectionOfState</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#CommonwealthElectoralDivision">asgs:CommonwealthElectoralDivision</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#LocalGovernmentArea">asgs:LocalGovernmentArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#IndigenousRegion">asgs:IndigenousRegion</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#UrbanCentreAndLocality">asgs:UrbanCentreAndLocality</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#IndigenousLocation">asgs:IndigenousLocation</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#Postalarea">asgs:PostalArea</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#GreaterCapitalCityStatisticalArea">asgs:GreaterCapitalCityStatisticalArea</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#SectionofState">asgs:SectionOfState</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#CommonwealthElectoralDivision">asgs:CommonwealthElectoralDivision</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#NaturalResourceManagementRegion">asgs:NaturalResourceManagementRegion</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#StateSuburb">asgs:StateSuburb</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#SignificantUrbanArea">asgs:SignificantUrbanArea</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#StateElectoralDivision">asgs:StateElectoralDivision</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#DestinationZone">asgs:DestinationZone</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#StateSuburb">asgs:StateSuburb</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#GreaterCapitalCityStatisticalArea">asgs:GreaterCapitalCityStatisticalArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#NaturalResourceManagementRegion">asgs:NaturalResourceManagementRegion</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#StatisticalAreaLevel3">asgs:StatisticalAreaLevel3</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#RemotenessArea">asgs:RemotenessArea</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#AustralianDrainageDivision">asgs:AustralianDrainageDivision</a><sup class="sup-c" title="class">c</sup><br/>
                     <a href="#IndigenousArea">asgs:IndigenousArea</a><sup class="sup-c" title="class">c</sup><br/>
-                </td>
-            </tr>
-            <tr>
-                <th>In domain of</th>
-                <td>
-                    <a href="#label">asgs:label</a><sup class="sup-dp" title="datatype property">dp</sup><br/>
-                    <a href="#code">asgs:code</a><sup class="sup-dp" title="datatype property">dp</sup><br/>
+                    <a href="#Country">asgs:Country</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#IndigenousRegion">asgs:IndigenousRegion</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#TourismRegion">asgs:TourismRegion</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#IndigenousLocation">asgs:IndigenousLocation</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="#StatisticalAreaLevel4">asgs:StatisticalAreaLevel4</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -499,7 +492,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -526,7 +519,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#IndigenousRegion">asgs:IndigenousRegion</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#IndigenousRegion">asgs:IndigenousRegion</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -553,7 +546,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#IndigenousArea">asgs:IndigenousArea</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#IndigenousArea">asgs:IndigenousArea</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -580,7 +573,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -595,7 +588,7 @@ code {
             <tr>
                 <th>Description</th>
                 <td>
-                    Local Government Areas (LGAs) are an ABS approximation of gazetted local government boundaries as defined by each State and Territory Local Government Department. LGAs cover incorporated areas of Australia. Incorporated areas are legally designated parts of a State or Territory over which incorporated local governing bodies have responsibility. The major areas of Australia not administered by incorporated bodies are the northern parts of South Australia and all of the Australian Capital Territory and the Other Territories. These regions are identified as Ã¢â‚¬ËœUnincorporatedÃ¢â‚¬â„¢ in the Australian Statistical Geography Standard (ASGS) LGA structure. A small number of LGA boundaries and names change each year and the ABS LGAs are updated on an annual basis to reflect these changes. LGAs are approximated using whole Mesh Blocks (MBs). In aggregation LGAs cover Australia without gaps or overlaps. The LGAs are Non ABS Structures within the ASGS. These are mostly administrative areas which are not defined or maintained by the ABS but for which the ABS is committed to providing a range of statistics.
+                    Local Government Areas (LGAs) are an ABS approximation of gazetted local government boundaries as defined by each State and Territory Local Government Department. LGAs cover incorporated areas of Australia. Incorporated areas are legally designated parts of a State or Territory over which incorporated local governing bodies have responsibility. The major areas of Australia not administered by incorporated bodies are the northern parts of South Australia and all of the Australian Capital Territory and the Other Territories. These regions are identified as â€˜Unincorporatedâ€™ in the Australian Statistical Geography Standard (ASGS) LGA structure. A small number of LGA boundaries and names change each year and the ABS LGAs are updated on an annual basis to reflect these changes. LGAs are approximated using whole Mesh Blocks (MBs). In aggregation LGAs cover Australia without gaps or overlaps. The LGAs are Non ABS Structures within the ASGS. These are mostly administrative areas which are not defined or maintained by the ABS but for which the ABS is committed to providing a range of statistics.
                 </td>
             </tr>
             <tr>
@@ -607,8 +600,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -635,13 +628,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
-                </td>
-            </tr>
-            <tr>
-                <th>In domain of</th>
-                <td>
-                    <a href="#category">asgs:category</a><sup class="sup-op" title="object property">op</sup><br/>
+                    <a href="http://purl.org/dc/terms/type">dcterms:type</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1<br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -663,12 +651,6 @@ code {
                 <th>Super-classes</th>
                 <td>
                     <a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a><sup class="sup-c" title="class">c</sup><br/>
-                </td>
-            </tr>
-            <tr>
-                <th>In range of</th>
-                <td>
-                    <a href="#category">asgs:category</a><sup class="sup-op" title="object property">op</sup><br/>
                 </td>
             </tr>
         </table>
@@ -695,8 +677,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -723,7 +705,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -750,7 +732,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -777,7 +759,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -804,7 +786,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#SectionofState">asgs:SectionOfState</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#SectionofState">asgs:SectionOfState</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -852,8 +834,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel1">asgs:StatisticalAreaLevel1</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -880,7 +862,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#Country">asgs:Country</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#Country">asgs:Country</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -907,8 +889,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -935,10 +917,10 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">max</span> 1 <a href="#RemotenessArea">asgs:RemotenessArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">max</span> 1 <a href="#IndigenousLocation">asgs:IndigenousLocation</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">max</span> 1 <a href="#UrbanCentreAndLocality">asgs:UrbanCentreAndLocality</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">max</span> 1 <a href="#RemotenessArea">asgs:RemotenessArea</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">max</span> 1 <a href="#IndigenousLocation">asgs:IndigenousLocation</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">max</span> 1 <a href="#UrbanCentreAndLocality">asgs:UrbanCentreAndLocality</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -965,8 +947,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">max</span> 1 <a href="#SignificantUrbanArea">asgs:SignificantUrbanArea</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel3">asgs:StatisticalAreaLevel3</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel3">asgs:StatisticalAreaLevel3</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">max</span> 1 <a href="#SignificantUrbanArea">asgs:SignificantUrbanArea</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -993,7 +975,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel4">asgs:StatisticalAreaLevel4</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StatisticalAreaLevel4">asgs:StatisticalAreaLevel4</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -1020,8 +1002,8 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">max</span> 1 <a href="#GreaterCapitalCityStatisticalArea">asgs:GreaterCapitalCityStatisticalArea</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#StateOrTerritory">asgs:StateOrTerritory</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">max</span> 1 <a href="#GreaterCapitalCityStatisticalArea">asgs:GreaterCapitalCityStatisticalArea</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -1048,7 +1030,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#contains">asgs:contains</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a> <span class="cardinality">min</span> 1 <a href="#StatisticalAreaLevel2">asgs:StatisticalAreaLevel2</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -1075,7 +1057,7 @@ code {
             <tr>
                 <th>Restrictions</th>
                 <td>
-                    <a href="#iswithin">asgs:within</a><sup class="sup-op" title="object property">op</sup> <span class="cardinality">exactly</span> 1 <a href="#SectionofStateRange">asgs:SectionOfStateRange</a><sup class="sup-c" title="class">c</sup><br/>
+                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a> <span class="cardinality">exactly</span> 1 <a href="#SectionofStateRange">asgs:SectionOfStateRange</a><sup class="sup-c" title="class">c</sup><br/>
                 </td>
             </tr>
         </table>
@@ -1084,64 +1066,14 @@ code {
 <section id="objectproperties">
     <h2>Object Properties <span style="float:right; font-size:smaller;"><a href="">&uparrow;</a></span></h2>
     <ul class="hlist">
-        <li><a href="#category">category</a></li>
-        <li><a href="#contains">contains</a></li>
-        <li><a href="#iswithin">is within</a></li>
+        <li><a href="#type">type</a></li>
     </ul>
-    <div class="entity property" id="category">
-        <h3>category<sup title="object property" class="sup-op">op</sup></h3>
+    <div class="entity property" id="type">
+        <h3>type<sup title="object property" class="sup-op">op</sup></h3>
         <table>
             <tr>
                 <th>IRI</th>
-                <td><code>http://linked.data.gov.au/def/asgs#category</code></td>
-            </tr>
-            <tr>
-                <th>Super-properties</th>
-                <td>
-                    <a href="http://purl.org/dc/terms/type">dcterms:type</a><sup class="sup-dp" title="datatype property">dp</sup>
-                </td>
-            </tr>
-            <tr>
-                <th>Domain(s)</th>
-                <td>
-                    <a href="#MeshBlock">asgs:MeshBlock</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-            <tr>
-                <th>Range(s)</th>
-                <td>
-                    <a href="#Meshblockcategory">asgs:MeshblockCategory</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <div class="entity property" id="contains">
-        <h3>contains<sup title="object property" class="sup-op">op</sup></h3>
-        <table>
-            <tr>
-                <th>IRI</th>
-                <td><code>http://linked.data.gov.au/def/asgs#contains</code></td>
-            </tr>
-            <tr>
-                <th>Super-properties</th>
-                <td>
-                    <a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <div class="entity property" id="iswithin">
-        <h3>is within<sup title="object property" class="sup-op">op</sup></h3>
-        <table>
-            <tr>
-                <th>IRI</th>
-                <td><code>http://linked.data.gov.au/def/asgs#within</code></td>
-            </tr>
-            <tr>
-                <th>Super-properties</th>
-                <td>
-                    <a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a>
-                </td>
+                <td><code>http://purl.org/dc/terms/type</code></td>
             </tr>
         </table>
     </div>
@@ -1150,80 +1082,14 @@ code {
 <section id="datatypeproperties">
     <h2>Datatype Properties <span style="float:right; font-size:smaller;"><a href="">&uparrow;</a></span></h2>
     <ul class="hlist">
-        <li><a href="#code">code</a></li>
-        <li><a href="#label">label</a></li>
         <li><a href="#identifier">identifier</a></li>
-        <li><a href="#type">type</a></li>
     </ul>
-    <div class="entity property" id="code">
-        <h3>code<sup title="datatype property" class="sup-dp">dp</sup></h3>
-        <table>
-            <tr>
-                <th>IRI</th>
-                <td><code>http://linked.data.gov.au/def/asgs#code</code></td>
-            </tr>
-            <tr>
-                <th>Super-properties</th>
-                <td>
-                    <a href="http://purl.org/dc/terms/identifier">dcterms:identifier</a><sup class="sup-dp" title="datatype property">dp</sup>
-                </td>
-            </tr>
-            <tr>
-                <th>Domain(s)</th>
-                <td>
-                    <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-            <tr>
-                <th>Range(s)</th>
-                <td>
-                    <a href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <div class="entity property" id="label">
-        <h3>label<sup title="datatype property" class="sup-dp">dp</sup></h3>
-        <table>
-            <tr>
-                <th>IRI</th>
-                <td><code>http://linked.data.gov.au/def/asgs#label</code></td>
-            </tr>
-            <tr>
-                <th>Super-properties</th>
-                <td>
-                    <a href="http://www.w3.org/2000/01/rdf-schema#label">rdfs:label</a>
-                </td>
-            </tr>
-            <tr>
-                <th>Domain(s)</th>
-                <td>
-                    <a href="#Feature">asgs:Feature</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-            <tr>
-                <th>Range(s)</th>
-                <td>
-                    <a href="http://www.w3.org/2001/XMLSchema#string">xsd:string</a><sup class="sup-c" title="class">c</sup>
-                </td>
-            </tr>
-        </table>
-    </div>
     <div class="entity property" id="identifier">
         <h3>identifier<sup title="datatype property" class="sup-dp">dp</sup></h3>
         <table>
             <tr>
                 <th>IRI</th>
                 <td><code>http://purl.org/dc/terms/identifier</code></td>
-            </tr>
-        </table>
-    </div>
-    <div class="entity property" id="type">
-        <h3>type<sup title="datatype property" class="sup-dp">dp</sup></h3>
-        <table>
-            <tr>
-                <th>IRI</th>
-                <td><code>http://purl.org/dc/terms/type</code></td>
             </tr>
         </table>
     </div>

--- a/asgs.html
+++ b/asgs.html
@@ -193,6 +193,7 @@ code {
 </head>
 <body>
 <div id="pylode">made by <a href="http://github.com/rdflib/pyLODE">pyLODE</a></div>
+<img src="./images/ABS_Logo_333.svg" style="width:200px;" alt="ABS Logo" /><br />
 <h1>ASGS Ontology</h1>
 <section id="metadata">
     <h2 style="display:none;">Metadata</h2>
@@ -279,7 +280,7 @@ code {
 <section id="overview">
     <h2>Overview</h2>
     <div class="figure">
-        <div style="width:500px; height:500px; background-color: black;">&nbsp;</div>
+        <div style="width:500px; height:500px; background-color: black;"><img src="./images/asgs-Statistical-Areas.png"/></div>
         <div class="caption"><strong>Figure 1:</strong> Ontology overview</div>
     </div>
 </section>

--- a/asgs.ttl
+++ b/asgs.ttl
@@ -49,8 +49,9 @@
   <li>http://linked.data.gov.au/def/asgs-path contains association classes and properties relating to paths between instances of the core classes</li>
   <li>http://linked.data.gov.au/def/asgs-isof (deprecated) contains specialized predicates for containment relationships - this functionality is provided by the generic 'within' and 'contains' relations</li>
   <li>http://linked.data.gov.au/def/asgs-code (deprecated) contains specialised annotation properties for identifiers and labels - this functionality has been superseded by a set of data-types to be used in conjunction with more generic properties</li>
+  <li>http://linked.data.gov.au/def/asgs-prop (deprecated) contains specialised ASGS properties for relationships, classifiers, identifiers and labels - this functionality has been superseded by use of types from standardized RDF vocabularies</li>
 </u>"""^^rdf:HTML ;
-                                      dcterms:modified "2020-01-14" ;
+                                      dcterms:modified "2020-02-03" ;
                                       dcterms:publisher "<a href='http://catalogue.linked.data.gov.au/org/O-000928'>Australian Bureau of Statistics</a>"^^rdf:HTML ;
                                       dcterms:rights "Copyright 2018 Australian Bureau of Statistics." ;
                                       dcterms:source <https://www.abs.gov.au/websitedbs/D3310114.nsf/home/Australian+Statistical+Geography+Standard+(ASGS)> ;
@@ -59,13 +60,6 @@
 #################################################################
 #    Annotation properties
 #################################################################
-
-###  http://linked.data.gov.au/def/asgs#label
-asgs:label rdf:type owl:AnnotationProperty ;
-           rdfs:subPropertyOf rdfs:label ;
-           rdfs:range xsd:string ;
-           rdfs:domain asgs:Feature .
-
 
 ###  http://purl.org/dc/terms/created
 dcterms:created rdf:type owl:AnnotationProperty .
@@ -112,52 +106,8 @@ rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
 
 
 #################################################################
-#    Object Properties
-#################################################################
-
-###  http://linked.data.gov.au/def/asgs#category
-asgs:category rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf dcterms:type ;
-              rdfs:domain asgs:MeshBlock ;
-              rdfs:range asgs:MeshblockCategory ;
-              rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
-              rdfs:label "category" ;
-              rdfs:seeAlso asgs:MeshBlock .
-
-
-###  http://linked.data.gov.au/def/asgs#contains
-asgs:contains rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf geo:sfContains ;
-              rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
-              rdfs:label "contains" ;
-              rdfs:seeAlso asgs:Feature .
-
-
-###  http://linked.data.gov.au/def/asgs#within
-asgs:within rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf geo:sfWithin ;
-            rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
-            rdfs:label "is within" ;
-            rdfs:seeAlso asgs:Feature .
-
-
-#################################################################
 #    Data properties
 #################################################################
-
-###  http://linked.data.gov.au/def/asgs#code
-asgs:code rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf dcterms:identifier ;
-          rdfs:domain asgs:Feature ;
-          rdfs:range xsd:string ;
-          rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
-          rdfs:label "code" ;
-          rdfs:seeAlso asgs:Feature .
-
-
-###  http://linked.data.gov.au/def/asgs#label
-asgs:label rdf:type owl:DatatypeProperty .
-
 
 ###  http://purl.org/dc/terms/identifier
 dcterms:identifier rdf:type owl:DatatypeProperty .
@@ -175,7 +125,7 @@ dcterms:type rdf:type owl:DatatypeProperty .
 asgs:AustralianDrainageDivision rdf:type owl:Class ;
                                 rdfs:subClassOf asgs:Feature ,
                                                 [ rdf:type owl:Restriction ;
-                                                  owl:onProperty asgs:contains ;
+                                                  owl:onProperty geo:sfContains ;
                                                   owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                   owl:onClass asgs:MeshBlock
                                                 ] ;
@@ -188,12 +138,12 @@ asgs:AustralianDrainageDivision rdf:type owl:Class ;
 asgs:CommonwealthElectoralDivision rdf:type owl:Class ;
                                    rdfs:subClassOf asgs:Feature ,
                                                    [ rdf:type owl:Restriction ;
-                                                     owl:onProperty asgs:contains ;
+                                                     owl:onProperty geo:sfContains ;
                                                      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                      owl:onClass asgs:StatisticalAreaLevel1
                                                    ] ,
                                                    [ rdf:type owl:Restriction ;
-                                                     owl:onProperty asgs:within ;
+                                                     owl:onProperty geo:sfWithin ;
                                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                      owl:onClass asgs:StateOrTerritory
                                                    ] ;
@@ -215,12 +165,12 @@ asgs:Country rdf:type owl:Class ;
 asgs:DestinationZone rdf:type owl:Class ;
                      rdfs:subClassOf asgs:Feature ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty asgs:contains ;
+                                       owl:onProperty geo:sfContains ;
                                        owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                        owl:onClass asgs:MeshBlock
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty asgs:within ;
+                                       owl:onProperty geo:sfWithin ;
                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                        owl:onClass asgs:StatisticalAreaLevel2
                                      ] ;
@@ -233,11 +183,11 @@ asgs:DestinationZone rdf:type owl:Class ;
 asgs:Feature rdf:type owl:Class ;
              rdfs:subClassOf geo:Feature ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty asgs:contains ;
+                               owl:onProperty geo:sfContains ;
                                owl:allValuesFrom asgs:Feature
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty asgs:within ;
+                               owl:onProperty geo:sfWithin ;
                                owl:allValuesFrom asgs:Feature
                              ] ;
              rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
@@ -248,7 +198,7 @@ asgs:Feature rdf:type owl:Class ;
 asgs:GreaterCapitalCityStatisticalArea rdf:type owl:Class ;
                                        rdfs:subClassOf asgs:Feature ,
                                                        [ rdf:type owl:Restriction ;
-                                                         owl:onProperty asgs:within ;
+                                                         owl:onProperty geo:sfWithin ;
                                                          owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                          owl:onClass asgs:StateOrTerritory
                                                        ] ;
@@ -261,7 +211,7 @@ asgs:GreaterCapitalCityStatisticalArea rdf:type owl:Class ;
 asgs:IndigenousArea rdf:type owl:Class ;
                     rdfs:subClassOf asgs:Feature ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty asgs:within ;
+                                      owl:onProperty geo:sfWithin ;
                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass asgs:IndigenousRegion
                                     ] ;
@@ -274,7 +224,7 @@ asgs:IndigenousArea rdf:type owl:Class ;
 asgs:IndigenousLocation rdf:type owl:Class ;
                         rdfs:subClassOf asgs:Feature ,
                                         [ rdf:type owl:Restriction ;
-                                          owl:onProperty asgs:within ;
+                                          owl:onProperty geo:sfWithin ;
                                           owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                           owl:onClass asgs:IndigenousArea
                                         ] ;
@@ -287,7 +237,7 @@ asgs:IndigenousLocation rdf:type owl:Class ;
 asgs:IndigenousRegion rdf:type owl:Class ;
                       rdfs:subClassOf asgs:Feature ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty asgs:within ;
+                                        owl:onProperty geo:sfWithin ;
                                         owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass asgs:StateOrTerritory
                                       ] ;
@@ -300,12 +250,12 @@ asgs:IndigenousRegion rdf:type owl:Class ;
 asgs:LocalGovernmentArea rdf:type owl:Class ;
                          rdfs:subClassOf asgs:Feature ,
                                          [ rdf:type owl:Restriction ;
-                                           owl:onProperty asgs:contains ;
+                                           owl:onProperty geo:sfContains ;
                                            owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                            owl:onClass asgs:MeshBlock
                                          ] ,
                                          [ rdf:type owl:Restriction ;
-                                           owl:onProperty asgs:within ;
+                                           owl:onProperty geo:sfWithin ;
                                            owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                            owl:onClass asgs:StateOrTerritory
                                          ] ;
@@ -319,9 +269,14 @@ asgs:LocalGovernmentArea rdf:type owl:Class ;
 asgs:MeshBlock rdf:type owl:Class ;
                rdfs:subClassOf asgs:Feature ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty asgs:within ;
+                                 owl:onProperty geo:sfWithin ;
                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                  owl:onClass asgs:StatisticalAreaLevel1
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty dcterms:type ;
+                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange asgs:MeshblockCategory
                                ] ;
                dcterms:description "Mesh Blocks (MB) are the smallest geographical area defined by the ABS. They are designed as geographic building blocks rather than as areas for the release of statistics themselves. All statistical areas in the Australian Statistical Geography Standard (ASGS) both ABS and Non ABS Structures are built up from one or more MBs.As a result the design of MBs takes into account many factors including administrative boundaries such as Cadastre (property boundaries) Suburbs and Localities and Local Government Areas (LGAs) as well as land uses and dwelling distribution. Most MBs contain 30 to 60 dwellings although some are specifically designed to have zero. This provides an additional level of confidentiality for data released on the ASGS as the difference in data released on multiple statistical areas is always at least one MB. Mesh Blocks like other ABS structures in the ASGS are stable for 5 years and are updated to reflect changes such as new housing developments every 5 years. The MB table includes a Mesh Block Category field that broadly defines primary land uses such as Residential and Commercial. MB boundaries are contiguous and in aggregate cover the whole of Australia without gaps or overlaps. An additional code (Outside Australia) has also been added to represent areas not covered by Geographical Australia." ;
                rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
@@ -330,22 +285,19 @@ asgs:MeshBlock rdf:type owl:Class ;
 
 ###  http://linked.data.gov.au/def/asgs#MeshblockCategory
 asgs:MeshblockCategory rdf:type owl:Class ;
-                       rdfs:subClassOf skos:Concept ;
-                       rdfs:comment "The class of meshblock categories, as defined in ASGS" ;
-                       rdfs:label "Meshblock category" ;
-                       rdfs:seeAlso <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Mesh%20Blocks%20(MB)~10012> .
+                       rdfs:subClassOf skos:Concept .
 
 
 ###  http://linked.data.gov.au/def/asgs#NaturalResourceManagementRegion
 asgs:NaturalResourceManagementRegion rdf:type owl:Class ;
                                      rdfs:subClassOf asgs:Feature ,
                                                      [ rdf:type owl:Restriction ;
-                                                       owl:onProperty asgs:contains ;
+                                                       owl:onProperty geo:sfContains ;
                                                        owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                        owl:onClass asgs:MeshBlock
                                                      ] ,
                                                      [ rdf:type owl:Restriction ;
-                                                       owl:onProperty asgs:within ;
+                                                       owl:onProperty geo:sfWithin ;
                                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                        owl:onClass asgs:StateOrTerritory
                                                      ] ;
@@ -358,7 +310,7 @@ asgs:NaturalResourceManagementRegion rdf:type owl:Class ;
 asgs:PostalArea rdf:type owl:Class ;
                 rdfs:subClassOf asgs:Feature ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty asgs:contains ;
+                                  owl:onProperty geo:sfContains ;
                                   owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                   owl:onClass asgs:MeshBlock
                                 ] ;
@@ -371,7 +323,7 @@ asgs:PostalArea rdf:type owl:Class ;
 asgs:RemotenessArea rdf:type owl:Class ;
                     rdfs:subClassOf asgs:Feature ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty asgs:within ;
+                                      owl:onProperty geo:sfWithin ;
                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass asgs:StateOrTerritory
                                     ] ;
@@ -384,7 +336,7 @@ asgs:RemotenessArea rdf:type owl:Class ;
 asgs:SectionOfState rdf:type owl:Class ;
                     rdfs:subClassOf asgs:Feature ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty asgs:within ;
+                                      owl:onProperty geo:sfWithin ;
                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass asgs:StateOrTerritory
                                     ] ;
@@ -397,7 +349,7 @@ asgs:SectionOfState rdf:type owl:Class ;
 asgs:SectionOfStateRange rdf:type owl:Class ;
                          rdfs:subClassOf asgs:Feature ,
                                          [ rdf:type owl:Restriction ;
-                                           owl:onProperty asgs:within ;
+                                           owl:onProperty geo:sfWithin ;
                                            owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                            owl:onClass asgs:SectionOfState
                                          ] ;
@@ -418,12 +370,12 @@ asgs:SignificantUrbanArea rdf:type owl:Class ;
 asgs:StateElectoralDivision rdf:type owl:Class ;
                             rdfs:subClassOf asgs:Feature ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty asgs:contains ;
+                                              owl:onProperty geo:sfContains ;
                                               owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                               owl:onClass asgs:StatisticalAreaLevel1
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty asgs:within ;
+                                              owl:onProperty geo:sfWithin ;
                                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                               owl:onClass asgs:StateOrTerritory
                                             ] ;
@@ -436,7 +388,7 @@ asgs:StateElectoralDivision rdf:type owl:Class ;
 asgs:StateOrTerritory rdf:type owl:Class ;
                       rdfs:subClassOf asgs:Feature ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty asgs:within ;
+                                        owl:onProperty geo:sfWithin ;
                                         owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass asgs:Country
                                       ] ;
@@ -449,12 +401,12 @@ asgs:StateOrTerritory rdf:type owl:Class ;
 asgs:StateSuburb rdf:type owl:Class ;
                  rdfs:subClassOf asgs:Feature ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty asgs:contains ;
+                                   owl:onProperty geo:sfContains ;
                                    owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass asgs:MeshBlock
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty asgs:within ;
+                                   owl:onProperty geo:sfWithin ;
                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass asgs:StateOrTerritory
                                  ] ;
@@ -467,22 +419,22 @@ asgs:StateSuburb rdf:type owl:Class ;
 asgs:StatisticalAreaLevel1 rdf:type owl:Class ;
                            rdfs:subClassOf asgs:Feature ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:StatisticalAreaLevel2
                                            ] ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:IndigenousLocation
                                            ] ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:RemotenessArea
                                            ] ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:UrbanCentreAndLocality
                                            ] ;
@@ -495,12 +447,12 @@ asgs:StatisticalAreaLevel1 rdf:type owl:Class ;
 asgs:StatisticalAreaLevel2 rdf:type owl:Class ;
                            rdfs:subClassOf asgs:Feature ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:StatisticalAreaLevel3
                                            ] ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:SignificantUrbanArea
                                            ] ;
@@ -513,7 +465,7 @@ asgs:StatisticalAreaLevel2 rdf:type owl:Class ;
 asgs:StatisticalAreaLevel3 rdf:type owl:Class ;
                            rdfs:subClassOf asgs:Feature ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:StatisticalAreaLevel4
                                            ] ;
@@ -526,12 +478,12 @@ asgs:StatisticalAreaLevel3 rdf:type owl:Class ;
 asgs:StatisticalAreaLevel4 rdf:type owl:Class ;
                            rdfs:subClassOf asgs:Feature ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:StateOrTerritory
                                            ] ,
                                            [ rdf:type owl:Restriction ;
-                                             owl:onProperty asgs:within ;
+                                             owl:onProperty geo:sfWithin ;
                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                              owl:onClass asgs:GreaterCapitalCityStatisticalArea
                                            ] ;
@@ -544,7 +496,7 @@ asgs:StatisticalAreaLevel4 rdf:type owl:Class ;
 asgs:TourismRegion rdf:type owl:Class ;
                    rdfs:subClassOf asgs:Feature ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty asgs:contains ;
+                                     owl:onProperty geo:sfContains ;
                                      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass asgs:StatisticalAreaLevel2
                                    ] ;
@@ -557,7 +509,7 @@ asgs:TourismRegion rdf:type owl:Class ;
 asgs:UrbanCentreAndLocality rdf:type owl:Class ;
                             rdfs:subClassOf asgs:Feature ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty asgs:within ;
+                                              owl:onProperty geo:sfWithin ;
                                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                               owl:onClass asgs:SectionOfStateRange
                                             ] ;
@@ -570,9 +522,9 @@ asgs:UrbanCentreAndLocality rdf:type owl:Class ;
 #    Annotations
 #################################################################
 
-asgs:label rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
-           rdfs:label "label" ;
-           rdfs:seeAlso asgs:Feature .
+asgs:MeshblockCategory rdfs:label "Meshblock category" ;
+                       rdfs:comment "The class of meshblock categories, as defined in ASGS" ;
+                       rdfs:seeAlso <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Mesh%20Blocks%20(MB)~10012> .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/asgs.ttl
+++ b/asgs.ttl
@@ -17,7 +17,6 @@
 
 <http://linked.data.gov.au/def/asgs> rdf:type owl:Ontology ;
                                       owl:imports <http://www.opengis.net/ont/geosparql> ;
-                                      dcterms:contributor "<a href='https://orcid.org/0000-0002-8742-7730'>Nicholas Car, Surround Australia</a>"^^rdf:HTML ;
                                       dcterms:created "2018-11-23" ;
                                       dcterms:creator "<a href='https://orcid.org/0000-0002-3884-3420'>Simon J D Cox, CSIRO</a>"^^rdf:HTML ,
                                                       "<a href='https://orcid.org/0000-0002-4305-6085'>Laurent Lefort, Australian Bureau of Statistics</a>"^^rdf:HTML ;
@@ -105,16 +104,24 @@ dcterms:title rdf:type owl:AnnotationProperty .
 rdfs:isDefinedBy rdf:type owl:AnnotationProperty .
 
 
+###  http://www.w3.org/2002/07/owl#qualifiedCardinality
+owl:qualifiedCardinality rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.org/dc/terms/type
+dcterms:type rdf:type owl:ObjectProperty .
+
+
 #################################################################
 #    Data properties
 #################################################################
 
 ###  http://purl.org/dc/terms/identifier
 dcterms:identifier rdf:type owl:DatatypeProperty .
-
-
-###  http://purl.org/dc/terms/type
-dcterms:type rdf:type owl:DatatypeProperty .
 
 
 #################################################################
@@ -268,15 +275,11 @@ asgs:LocalGovernmentArea rdf:type owl:Class ;
 ###  http://linked.data.gov.au/def/asgs#MeshBlock
 asgs:MeshBlock rdf:type owl:Class ;
                rdfs:subClassOf asgs:Feature ,
+                               <http://org.semanticweb.owlapi/error#Error1> ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty geo:sfWithin ;
                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                  owl:onClass asgs:StatisticalAreaLevel1
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty dcterms:type ;
-                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                 owl:onDataRange asgs:MeshblockCategory
                                ] ;
                dcterms:description "Mesh Blocks (MB) are the smallest geographical area defined by the ABS. They are designed as geographic building blocks rather than as areas for the release of statistics themselves. All statistical areas in the Australian Statistical Geography Standard (ASGS) both ABS and Non ABS Structures are built up from one or more MBs.As a result the design of MBs takes into account many factors including administrative boundaries such as Cadastre (property boundaries) Suburbs and Localities and Local Government Areas (LGAs) as well as land uses and dwelling distribution. Most MBs contain 30 to 60 dwellings although some are specifically designed to have zero. This provides an additional level of confidentiality for data released on the ASGS as the difference in data released on multiple statistical areas is always at least one MB. Mesh Blocks like other ABS structures in the ASGS are stable for 5 years and are updated to reflect changes such as new housing developments every 5 years. The MB table includes a Mesh Block Category field that broadly defines primary land uses such as Residential and Commercial. MB boundaries are contiguous and in aggregate cover the whole of Australia without gaps or overlaps. An additional code (Outside Australia) has also been added to represent areas not covered by Geographical Australia." ;
                rdfs:isDefinedBy <http://linked.data.gov.au/def/asgs> ;
@@ -285,7 +288,10 @@ asgs:MeshBlock rdf:type owl:Class ;
 
 ###  http://linked.data.gov.au/def/asgs#MeshblockCategory
 asgs:MeshblockCategory rdf:type owl:Class ;
-                       rdfs:subClassOf skos:Concept .
+                       rdfs:subClassOf skos:Concept ;
+                       rdfs:comment "The class of meshblock categories, as defined in ASGS" ;
+                       rdfs:label "Meshblock category" ;
+                       rdfs:seeAlso <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Mesh%20Blocks%20(MB)~10012> .
 
 
 ###  http://linked.data.gov.au/def/asgs#NaturalResourceManagementRegion
@@ -518,13 +524,11 @@ asgs:UrbanCentreAndLocality rdf:type owl:Class ;
                             rdfs:label "UrbanCentreAndLocality" .
 
 
-#################################################################
-#    Annotations
-#################################################################
+###  http://org.semanticweb.owlapi/error#Error1
+<http://org.semanticweb.owlapi/error#Error1> rdf:type owl:Class .
 
-asgs:MeshblockCategory rdfs:label "Meshblock category" ;
-                       rdfs:comment "The class of meshblock categories, as defined in ASGS" ;
-                       rdfs:seeAlso <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Mesh%20Blocks%20(MB)~10012> .
 
+[ owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger
+] .
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Remove specialized ASGS properties :contains :within :category :code :label and replace their use with geo:sfContains geo:sfWithin dcterms:type dcterms:identifier rdfs:label

fixes #26 