### PR TITLE
Time-independent datatypes for codes and names

### DIFF
--- a/asgs-id.ttl
+++ b/asgs-id.ttl
@@ -1,5 +1,6 @@
 # baseURI: http://linked.data.gov.au/def/asgs/id
 # imports: http://linked.data.gov.au/def/asgs
+# prefix: asgs-id
 
 @prefix asgs: <http://linked.data.gov.au/def/asgs#> .
 @prefix asgs-id: <http://linked.data.gov.au/def/asgs/id#> .
@@ -599,8 +600,22 @@ asgs:UrbanCentreAndLocality
   dcterms:publisher "<a href='http://catalogue.linked.data.gov.au/org/csiro'>CSIRO</a>"^^rdf:HTML ;
   dcterms:rights "Copyright 2020 CSIRO" ;
   dcterms:title "ASGS Ontology - code properties" ;
-  rdfs:comment """The datatypes were initially generated from the retired datatype-properties using SPARQL and later updated to match the patterns specified in the ASGS documentation. """ ;
+  rdfs:comment "The datatypes were initially generated from the retired datatype-properties using SPARQL and later updated to match the patterns specified in the ASGS documentation. " ;
   owl:imports <http://linked.data.gov.au/def/asgs> ;
+.
+asgs-id:addCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "addCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
 .
 asgs-id:addCode2011
   a rdfs:Datatype ;
@@ -626,6 +641,20 @@ asgs-id:addCode2016
       owl:withRestrictions (
           [
             xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:addName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "addName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 100 ;
           ]
         ) ;
     ] ;
@@ -658,6 +687,19 @@ asgs-id:addName2016
         ) ;
     ] ;
 .
+asgs-id:ausCode
+  a rdfs:Datatype ;
+  rdfs:label "ausCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:ausCode2011
   a rdfs:Datatype ;
   rdfs:label "ausCode2011" ;
@@ -684,6 +726,9 @@ asgs-id:ausCode2016
         ) ;
     ] ;
 .
+asgs-id:cedCode
+  a rdfs:Datatype ;
+.
 asgs-id:dzn5dig11
   a rdfs:Datatype ;
   rdfs:label "dzn5dig11" ;
@@ -693,6 +738,30 @@ asgs-id:dzn5dig11
       owl:withRestrictions (
           [
             xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:dznCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/mf/8000.0> ;
+  rdfs:comment """DESTINATION ZONE CODING CONVENTIONS
+
+A 2016 Destination Zone is identifiable by a 9 digit code. This comprises the State or Territory, Statistical Area Level 2 and Destination Zone identifier code. A Destination Zone identifier is only unique within a State or Territory. Destination Zones do not have names.
+
+Example: 111728922
+S/T	SA2	DZN
+1	1172	8922""" ;
+  rdfs:label "dznCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "9"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -730,6 +799,39 @@ S/T	SA2	DZN
           ]
           [
             xsd:length "9"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:gccsaCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Greater%20Capital%20City%20Statistical%20Areas%20(GCCSA)~10003> ;
+  rdfs:comment """GCCSA CODING STRUCTURE
+
+A GCCSA is identified by a 5-character alphanumeric code. This comprises a 1-digit State and Territory identifier followed by a 4-character GCCSA identifier that is unique within each State and Territory.
+
+Example 1:
+
+1GSYD Greater Sydney
+- State and Territory identifier: 1
+- GCCSA identifier: GSYD
+
+Example 2:
+
+Rest of NSW - 1RNSW
+- State and Territory identifier: 1
+- GCCSA identifier: RNSW
+
+Special Purpose GCCSA
+
+There are non-spatial GCCSAs for Migratory - Offshore - Shipping and No Usual Address in each State and Territory""" ;
+  rdfs:label "gccsaCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[1-9][A-Z]{4}" ;
           ]
         ) ;
     ] ;
@@ -796,6 +898,27 @@ There are non-spatial GCCSAs for Migratory - Offshore - Shipping and No Usual Ad
       owl:withRestrictions (
           [
             xsd:pattern "[1-9][A-Z]{4}" ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:gccsaName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Greater%20Capital%20City%20Statistical%20Areas%20(GCCSA)~10003> ;
+  rdfs:comment """GCCSA NAMES
+
+GCCSAs are named according to the cities they represent, for example, Greater Sydney.
+
+The remainder of the State and Territory is named Rest of <State>, for example, Rest of NSW.
+
+The exceptions to this are the ACT, as the whole of the ACT is included in the GCCSA, and the OTs, which do not have a capital city.""" ;
+  rdfs:label "gccsaName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -875,6 +998,43 @@ There are non-spatial GCCSAs for Migratory - Offshore - Shipping and No Usual Ad
         ) ;
     ] ;
 .
+asgs-id:iareCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Area%20(IARE)~7> ;
+  rdfs:comment """INDIGENOUS AREA CODING STRUCTURE
+Indigenous Areas have a six digit hierarchical code. Indigenous Areas are allocated a three digit code. This is prefixed by the three digit Indigenous Region code to complete the Indigenous Area code.
+
+Special purpose codes are included as balancing items. Statistical Area Level 1 (SA1) allocated to these codes are not part of a distinct Indigenous Area.
+
+Codes ending in 94 are reserved for cases where people are coded to No Usual Address SA1s.
+Codes ending in 97 are reserved for cases where people are coded to Migratory, Offshore and Shipping SA1s.
+
+Example:
+State and Territory Name	State and Territory Code	Indigenous Area Code	Indigenous Area Name
+Victoria	2	201001	Brimbank
+Victoria	2	201002	Cardinia
+Victoria	2	201003	Craigieburn - Sunbury
+Victoria	2	201004	Cranbourne - Narre Warren
+Victoria	2	201005	Frankston
+Victoria	2	201006	Greater Dandenong
+Victoria	2	294994	No usual address (Vic.)
+Victoria	2	297997	Migratory - Offshore - Shipping (Vic.)
+
+The codes used for the 2016 Indigenous Areas may not match those used in 2011 in some instances. In future ASGS editions, it may also be necessary to allocate new codes . Changes to codes occur where an Indigenous Area is abolished or changes significantly for new editions of the ASGS, the Indigenous Area identifier will be retired and the replacement Indigenous Area(s) given a new code. Correspondences enabling translation of data from 2011 to 2016 and how these changes have been applied will be released with this volume.""" ;
+  rdfs:label "iareCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "6"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:iareCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Area%20(IARE)~7> ;
@@ -949,6 +1109,22 @@ The codes used for the 2016 Indigenous Areas may not match those used in 2011 in
         ) ;
     ] ;
 .
+asgs-id:iareName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Area%20(IARE)~7> ;
+  rdfs:comment """INDIGENOUS AREA NAMES
+Indigenous Area Names are allocated by ABS and are generally based upon a commonly identified name or combination of names for the area/community which the boundary encompasses. In areas encompassing multiple communities a combination of up to three distinct community names have been used to label the area.""" ;
+  rdfs:label "iareName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:iareName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Area%20(IARE)~7> ;
@@ -977,6 +1153,43 @@ Indigenous Area Names are allocated by ABS and are generally based upon a common
       owl:withRestrictions (
           [
             xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:ilocCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Locations%20(ILOC)~6> ;
+  rdfs:comment """INDIGENOUS LOCATION CODING STRUCTURE
+Each Indigenous Location has a unique eight digit hierarchical code. Indigenous Locations are allocated a two digit code. This is prefixed by the six digit Indigenous Area code to complete the Indigenous Location code.
+
+Special purpose codes are included as balancing items. SA1s allocated to these codes are not part of a distinct Indigenous Location.
+
+Codes ending in 94 are reserved for cases where people are coded to No Usual Address SA1s.
+Codes ending in 97 are reserved for cases where people are coded to Migratory, Offshore and Shipping SA1s.
+
+Example:
+State and Territory Name	State and Territory Code	Indigenous Location Code	Indigenous Location Name
+Victoria	2	20100101	Keilor
+Victoria	2	20100102	Sunshine
+Victoria	2	20100201	Cardinia
+Victoria	2	20100301	Craigieburn - Sunbury
+Victoria	2	20100401	Cranbourne
+Victoria	2	20100402	Hallam - Berwick - Pearcedale
+Victoria	2	29499494	No usual address (Vic.)
+Victoria	2	29799797	Migratory - Offshore - Shipping (Vic.)
+
+The codes used for the 2016 Indigenous Locations may not match those used in 2011 in some instances. In future ASGS editions, it may also be necessary to allocate new codes . Changes to codes occur where an Indigenous Location is abolished or changes significantly for new editions of the ASGS, the Indigenous Location identifier will be retired and the replacement Indigenous Location(s) given a new code. Correspondences enabling translation of data from 2011 to 2016 and how these changes have been applied will be released with this volume.""" ;
+  rdfs:label "ilocCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "8"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1051,6 +1264,22 @@ The codes used for the 2016 Indigenous Locations may not match those used in 201
           ]
           [
             xsd:length "8"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:ilocName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Locations%20(ILOC)~6> ;
+  rdfs:comment """INDIGENOUS LOCATION NAMES
+Indigenous Location names are allocated by ABS and are generally based upon a commonly identified name or combination of names for the area/community that the boundary encompasses. In locations encompassing multiple communities a combination of up to three distinct community names have been used to label the location.""" ;
+  rdfs:label "ilocName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1157,6 +1386,39 @@ The codes used for the 2016 Indigenous Regions may not match those used in 2011 
         ) ;
     ] ;
 .
+asgs-id:iregCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Regions%20(IREG)~8> ;
+  rdfs:comment """INDIGENOUS REGION CODING STRUCTURE
+Indigenous Regions are allocated a two digit code. This is prefixed by a single digit State and Territory code to complete the Indigenous Region code.
+
+Special purpose codes are included as balancing items. Statistical Area Level 1 (SA1) allocated to these codes are not part of a distinct Indigenous Region.
+
+Codes ending in 94 are reserved for cases where people are coded to No Usual Address SA1s.
+Codes ending in 97 are reserved for cases where people are coded to Migratory, Offshore and Shipping SA1s.
+
+Example:
+State and Territory Name	State and Territory Code	Indigenous Region Code	Indigenous Region Name
+Victoria	2	201	Melbourne
+Victoria	2	202	Victoria exc. Melbourne
+Victoria	2	294	No usual address (Vic.)
+Victoria	2	297	Migratory - Offshore - Shipping (Vic.)
+
+The codes used for the 2016 Indigenous Regions may not match those used in 2011 in some instances. In future ASGS editions, it may also be necessary to allocate new codes . Changes to codes occur where an Indigenous Region is abolished or changes significantly for new editions of the ASGS, the Indigenous Region identifier will be retired and the replacement Indigenous Region(s) given a new code. Correspondences enabling translation of data from 2011 to 2016 and how these changes have been applied will be released with this volume.""" ;
+  rdfs:label "iregCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "3"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:iregCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Regions%20(IREG)~8> ;
@@ -1223,6 +1485,22 @@ The codes used for the 2016 Indigenous Regions may not match those used in 2011 
         ) ;
     ] ;
 .
+asgs-id:iregName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Regions%20(IREG)~8> ;
+  rdfs:comment """INDIGENOUS REGION NAMES
+Indigenous Region Names are allocated by ABS and are generally based upon a commonly identified name or combination of names for the area/community which the boundary encompasses.""" ;
+  rdfs:label "iregName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:iregName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.002~July%202016~Main%20Features~Indigenous%20Regions%20(IREG)~8> ;
@@ -1251,6 +1529,45 @@ Indigenous Region Names are allocated by ABS and are generally based upon a comm
       owl:withRestrictions (
           [
             xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:lgaCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Local%20Government%20Areas%20(LGAs)~2> ;
+  rdfs:comment """Local Government Area Coding Structure
+
+Local Government Areas are identified by four digit codes. Codes are unique only within a State or Territory. For unique Australia-wide Local Government Area code identification, the four digit code must be preceded by the State or Territory code. All Local Government Area codes end with the digit 0.
+
+The codes used for the 2019 Local Government Areas match those used in 2018, as there has been no change. Changes to codes occur where a Local Government Area is abolished or changes significantly. The previous code will be retired and the replacement Local Government Area will be given a new code.
+
+Non-spatial special purpose codes are included as balancing items. Mesh Blocks allocated to these codes are not part of Local Government Area.
+LGA code 9799 is reserved for cases where people are coded to Migratory, Off-shore and Shipping Mesh Blocks.
+LGA code 9499 is reserved for cases where people are coded to No usual address Mesh Blocks.
+
+Example:
+State Name	State Code	Local Government
+Area Code	Local Government Area Name
+Queensland	3	31000	Brisbane (C)
+Queensland	3	31750	Bulloo (S)
+Queensland	3	31820	Bundaberg (R)
+Queensland	3	31900	Burdekin (S)
+Queensland	3	32080	Cairns (R)
+Queensland	3	32250	Carpentaria (S)
+Queensland	3	32260	Cassowary Coast (R)
+Queensland	3	39799	Migratory - Offshore - Shipping (Qld)
+Queensland	3	39499	No usual address (Qld)""" ;
+  rdfs:label "lgaCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "5"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1294,6 +1611,36 @@ Queensland	3	39499	No usual address (Qld)""" ;
         ) ;
     ] ;
 .
+asgs-id:lgaName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Local%20Government%20Areas%20(LGAs)~2> ;
+  rdfs:comment """Local Government Area Names
+
+Local Government Area names are abbreviated in this structure. A suffix also indicates the Local Government Area status. Examples of these include:
+City of Albury: Albury (C)
+District Council of Copper Coast: Copper Coast (DC)
+
+Where the same Local Government Area name appears in different States or Territories, the State or Territory abbreviation appears in parenthesis after the name. Local Government Area names are therefore unique.
+
+In all States and the Northern Territory each incorporated area has an official status. In this ASGS edition, the various Local Government Area status types include:
+New South Wales: Cities (C) and Areas (A)
+Victoria: Cities (C), Rural Cities (RC), Boroughs (B) and Shires (S)
+Queensland: Cities (C), Shires (S), Towns (T) and Regional Councils (R)
+South Australia: Cities (C), Rural Cities (RC), Municipalities/Municipal Councils (M), District Councils (DC), Regional Councils (RegC), Towns (T) and Aboriginal Councils (AC)
+Western Australia: Cities (C), Towns (T) and Shires (S)
+Tasmania: Cities (C) and Municipalities (M)
+Northern Territory: Cities (C), Towns (T), Municipalities (M) and Shires (S).""" ;
+  rdfs:label "lgaName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:lgaName2012
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Local%20Government%20Areas%20(LGAs)~2> ;
@@ -1320,6 +1667,33 @@ Northern Territory: Cities (C), Towns (T), Municipalities (M) and Shires (S)."""
       owl:withRestrictions (
           [
             xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:mbCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Mesh%20Blocks%20(MB)~10012> ;
+  rdfs:comment """MESH BLOCK CODE
+
+The 11-digit Mesh Block code comprises: State and Territory identifier (1 digit), and a Mesh Block identifier (10 digits).
+
+Example: 60106840000
+S/T	MB
+6	0106840000
+Mesh Block Identifier Ranges
+
+Within each State and Territory, the Mesh Block identifier range 0000000000 to 9999999999.""" ;
+  rdfs:label "mbCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "11"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1378,6 +1752,20 @@ Within each State and Territory, the Mesh Block identifier range 0000000000 to 9
         ) ;
     ] ;
 .
+asgs-id:nrmrCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "nrmrCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:nrmrCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -1406,6 +1794,20 @@ asgs-id:nrmrCode2016
         ) ;
     ] ;
 .
+asgs-id:nrmrName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "nrmrName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:nrmrName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -1430,6 +1832,23 @@ asgs-id:nrmrName2016
       owl:withRestrictions (
           [
             xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:poaCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "poaCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "5"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1468,6 +1887,20 @@ asgs-id:poaCode2016
         ) ;
     ] ;
 .
+asgs-id:poaName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "poaName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:poaName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -1492,6 +1925,37 @@ asgs-id:poaName2016
       owl:withRestrictions (
           [
             xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:raCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Latestproducts/1270.0.55.005Main%20Features15July%202016?opendocument&tabname=Summary&prodno=1270.0.55.005&issue=July%202016&num=&view=> ;
+  rdfs:comment """A Remoteness Area is identifiable by a 2 digit hierarchical code. This comprises a State or Territory identifier and a Remoteness Area identifier code. A Remoteness Area identifier is only unique if it is preceded by the State or Territory identifier.
+
+As an example the Remoteness Area naming and coding structure for New South Wales (NSW) is illustrated below in Table 3.
+
+Table 3: Remoteness Area naming and coding structure for NSW
+
+State or Territory Code	State or Territory Name	Remoteness Area Category	Remoteness Area Code	Remoteness Area Name
+1	New South Wales	0	10	Major Cities of Australia
+1	New South Wales	1	11	Inner Regional Australia
+1	New South Wales	2	12	Outer Regional Australia
+1	New South Wales	3	13	Remote Australia
+1	New South Wales	4	14	Very Remote Australia
+1	New South Wales	5	15	Migratory - Offshore - Shipping (NSW)
+1	New South Wales	9	19	No usual address (NSW)""" ;
+  rdfs:label "raCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "2"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -1558,6 +2022,34 @@ State or Territory Code	State or Territory Name	Remoteness Area Category	Remoten
         ) ;
     ] ;
 .
+asgs-id:raName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Latestproducts/1270.0.55.005Main%20Features15July%202016?opendocument&tabname=Summary&prodno=1270.0.55.005&issue=July%202016> ;
+  rdfs:comment """Table 1: 2016 Remoteness Area Category Names for Australia and SA1 Average ARIA+ Value
+
+Remoteness Area Category	Remoteness Area Name	SA1 Average ARIA+ Value Ranges
+0	Major Cities of Australia	0 to 0.2
+1	Inner Regional Australia	greater than 0.2 and less than or equal to 2.4
+2	Outer Regional Australia	greater than 2.4 and less than or equal to 5.92
+3	Remote Australia			greater than 5.92 and less than or equal to 10.53
+4	Very Remote Australia		greater than 10.53
+5	Migratory - Offshore - Shipping	 Not Applicable
+9	No usual address			Not Applicable
+""" ;
+  rdfs:label "raName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "Major Cities of Australia"
+          "Inner Regional Australia"
+          "Outer Regional Australia"
+          "Remote Australia"
+          "Very Remote Australia"
+          "Migratory - Offshore - Shipping"
+          "No usual address"
+        ) ;
+    ] ;
+.
 asgs-id:raName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Latestproducts/1270.0.55.005Main%20Features15July%202016?opendocument&tabname=Summary&prodno=1270.0.55.005&issue=July%202016> ;
@@ -1611,6 +2103,50 @@ Remoteness Area Category	Remoteness Area Name	SA1 Average ARIA+ Value Ranges
           "Very Remote Australia"
           "Migratory - Offshore - Shipping"
           "No usual address"
+        ) ;
+    ] ;
+.
+asgs-id:sa1Code
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%201%20(SA1)~10013> ;
+  rdfs:comment """SA1 CODING STRUCTURE
+
+SA1s are not named. They are identified either by an 11-digit fully hierarchical code, or by a truncated 7-digit code comprising the State and Territory, SA2 and SA1 identifiers. The SA1 identifier is a 2-digit code, assigned within a SA2. A SA1 code is only unique within a State and Territory when it is preceded by the State and Territory identifier.
+
+11-digit Code
+
+An 11-digit SA1 code is fully hierarchical, and comprises: State and Territory identifier, SA4 identifier, SA3 identifier, SA2 identifier and a SA1 identifier.
+
+Example: SA1 50302104118
+S/T	SA4	SA3	SA2	SA1
+5	03	02	1041	18
+
+
+7-digit Code
+
+A 7-digit SA1 code is not fully hierarchical and comprises: State and Territory identifier, SA2 identifier and SA1 identifier.
+
+Example: SA1 5104118
+S/T	SA2	SA1
+5	1041	18
+Future Allocation of SA1 Codes
+
+In the future, it may be necessary to allocate new codes. If a SA1 is abolished, or changes significantly for new editions of the ASGS, the SA1 identifier will be retired and the replacement SA1(s) given the next available previously unused SA1 identifier within the SA2.
+
+SA1 Identifier Ranges
+
+Within each SA2, the SA1 identifier is in the data range 01 to 99.""" ;
+  rdfs:label "sa1Code" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "11"^^xsd:nonNegativeInteger ;
+          ]
         ) ;
     ] ;
 .
@@ -1702,6 +2238,50 @@ Within each SA2, the SA1 identifier is in the data range 01 to 99.""" ;
         ) ;
     ] ;
 .
+asgs-id:sa2Code
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%202%20(SA2)~10014> ;
+  rdfs:comment """SA2 CODING STRUCTURE
+
+A SA2 is identifiable either by a 9-digit fully hierarchical code, or by a truncated 5-digit code comprising the State and Territory and SA2 identifiers. The SA2 identifier is a 4-digit code, assigned in alphabetical order within a SA3. A SA2 code is only unique within a State and Territory if it is preceded by the State and Territory identifier.
+
+9-digit Code
+
+A 9-digit SA2 code is fully hierarchical, and comprises: State and Territory identifier, Statistical Area Level 4 (SA4) identifier, SA3 identifier, SA2 identifier.
+
+Example: 503021041 Perth City
+S/T	SA4	SA3	SA2	SA2
+5	03	02	1041	Perth City
+
+5-digit Code
+
+A 5-digit SA2 code is not hierarchical, and comprises only State and Territory identifier, SA2 identifier.
+
+Example: 51041 Perth City
+S/T	SA2	SA2 Name
+5	1041	Perth City
+
+Future Allocation of SA2 Codes
+
+In the future, it may be necessary to allocate new codes. If a SA2 is abolished, or changes significantly for new editions of the ASGS, the SA2 identifier will be retired and the replacement SA2(s) given the next available previously unused SA2 identifier within the State and Territory.
+
+SA2 Identifier Ranges
+
+Within each State and Territory, the SA2 identifier is in the data range 0001-7999. SA2 identifiers in the range 8000-8999 are reserved for processing within the ABS. The range 9000 to 9999 is reserved for special purpose SA2s.""" ;
+  rdfs:label "sa2Code" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "9"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sa2Maincode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%202%20(SA2)~10014> ;
@@ -1786,6 +2366,51 @@ Within each State and Territory, the SA2 identifier is in the data range 0001-79
           ]
           [
             xsd:length "9"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:sa2Name
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%202%20(SA2)~10014> ;
+  rdfs:comment """SA2 NAMES
+
+The key criteria for SA2 names are that they be:
+meaningful
+have a maximum of 40 characters
+unique, i.e. not shared by any other SA2 in Australia.
+
+In large urban areas, SA2s are named for the gazetted suburbs that comprise them:
+where a SA2 is made from a single suburb, it will retain the name of the suburb, for example:
+Duffy (ACT)
+Macgregor (ACT)
+
+where a single large suburb is split into more than one SA2, it will retain the name of the suburb and a geographic identifier, for example:
+Mount Waverley - North
+Mount Waverley - South.
+
+where a SA2 is made up from 2 or 3 suburbs, then the SA2 name is a concatenation of the suburb names, for example:
+Greenfield Park - Prairiewood
+Bayswater - Embleton - Bedford.
+where a SA2 is made up of 4 or more suburbs it will be named for the larger or more prominent suburbs, or given a local identifier, for example:
+Homebush Bay - Silverwater
+Pioneer Valley.
+
+In rural areas, SA2s are named for the gazetted localities that comprise them, or the towns, city, or region with which they are associated, for example:
+Benalla Region
+Townsville - South
+Bulahdelah - Stroud.
+
+Where a SA2 name is duplicated in two or more State and Territory, the State and Territory abbreviation is attached to the SA2 name, for example:
+O'Connor (ACT)
+O'Connor (WA).""" ;
+  rdfs:label "sa2Name" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 40 ;
           ]
         ) ;
     ] ;
@@ -1880,6 +2505,38 @@ O'Connor (WA).""" ;
         ) ;
     ] ;
 .
+asgs-id:sa3Code
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%203%20(SA3)~10015> ;
+  rdfs:comment """SA3 CODING STRUCTURE
+
+A SA3 is identified by a 5-digit hierarchical code. This comprises a 1-digit State and Territory identifier followed by a 2-digit SA4 identifier, unique within each State and Territory, and a 2-digit SA3 identifier, unique within each SA4.
+
+Example: 11401 Shoalhaven
+S/T	SA4	SA3	SA3 Name
+1	14	01	Shoalhaven
+
+Future Allocation of SA3 Codes
+
+In the future, it may be necessary to allocate new codes. If a SA3 is abolished, or changes significantly for new editions of the ASGS, the SA3 identifier will be retired and the replacement SA3(s) given the next available previously unused SA3 identifier within the SA4.
+
+SA3 Identifier Ranges
+
+Within each State and Territory, the SA3 identifier is in the data range 01-79. SA3 identifiers in the range 80-99 are reserved for special purpose SA3s.""" ;
+  rdfs:label "sa3Code" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "5"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sa3Code2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%203%20(SA3)~10015> ;
@@ -1940,6 +2597,45 @@ Within each State and Territory, the SA3 identifier is in the data range 01-79. 
           ]
           [
             xsd:length "5"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:sa3Name
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%203%20(SA3)~10015> ;
+  rdfs:comment """SA3 NAMES
+
+The key criteria for SA3 names are that they be:
+
+meaningful
+have a maximum of 40 characters
+unique, i.e. not shared by any other SA3 in Australia.
+SA3s are named according to the areas they represent:
+where a SA3 represents a well-known regional area or a State Regional Development Area it is named after that region, for example:
+Southern Highlands
+Mid West.
+
+where a SA3 represents the functional area of a regional city it is named after that city, for example, Wagga Wagga. In some cases the name of an associated town or region is also included, for example:
+Griffith - Murrumbidgee (West)
+
+where a SA3 represents an economic hub within a major city it is generally named to reflect that hub, for example:
+Parramatta
+
+where a SA3 represents a group of related suburbs it is named after one or more of those suburbs that reflect its location and extent, for example:
+North Sydney - Mosman
+Brunswick - Coburg.
+
+where a SA3 name is not unique within Australia, it is followed by the State and Territory abbreviation in brackets, for example:
+Central Highlands (Tas.)
+Central Highlands (Qld).""" ;
+  rdfs:label "sa3Name" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 40 ;
           ]
         ) ;
     ] ;
@@ -2022,6 +2718,39 @@ Central Highlands (Qld).""" ;
         ) ;
     ] ;
 .
+asgs-id:sa4Code
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%204%20(SA4)~10016> ;
+  rdfs:comment """SA4 CODING STRUCTURE
+
+A SA4 is identified by a 3-digit hierarchical code. This comprises a 1-digit State and Territory identifier, which precedes a 2-digit SA4 identifier, which is unique within each State and Territory.
+
+Example: 102 Central Coast
+S/T	SA4	SA4 Name
+1	02	Central Coast
+
+
+Future Allocation of SA4 Codes
+
+In the future, it may be necessary to allocate new codes. If a SA4 is abolished, or changes significantly for new editions of the ASGS, the SA4 identifier will be retired and the replacement SA4(s) given the next available previously unused SA4 identifier within the State and Territory.
+
+SA4 Identifier Ranges
+
+Within each State and Territory, the SA4 identifier is in the range 01- 79. SA4 identifiers in the range 80-99 are reserved for special purpose SA4s.""" ;
+  rdfs:label "sa4Code" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "3"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sa4Code2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%204%20(SA4)~10016> ;
@@ -2084,6 +2813,42 @@ Within each State and Territory, the SA4 identifier is in the range 01- 79. SA4 
           ]
           [
             xsd:length "3"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:sa4Name
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Statistical%20Area%20Level%204%20(SA4)~10016> ;
+  rdfs:comment """SA4 NAMES
+
+The key criteria for SA4 names are that they be:
+
+meaningful
+have a maximum of 40 characters
+unique, i.e. not shared by any other SA4 in Australia.
+
+SA4s are named according to the areas they represent:
+where a SA4 represents a labour market of a major city it is named after that city, for example:
+Bendigo
+
+where a SA4 represents an employment centre within a larger city it is generally named to reflect both the larger city and the employment centre or part of the city that it represents, for example:
+Melbourne - Inner South
+Sydney - Blacktown
+
+where a SA4 represents a collection of labour markets in regional areas it is named using either a description of that part of the State and Territory or after one or more well-known regional areas that it closely replicates, for example:
+Latrobe - Gippsland
+
+where this name does not identify it within Australia, it is generally preceded by the State and Territory name, for example:
+Western Australia - Wheat Belt
+Queensland - Outback.""" ;
+  rdfs:label "sa4Name" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 40 ;
           ]
         ) ;
     ] ;
@@ -2311,6 +3076,134 @@ No usual address (ACT)""" ;
           ]
           [
             xsd:length "3"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:sedCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~State%20Electoral%20Divisions%20(SEDs)~3> ;
+  rdfs:comment """STATE ELECTORAL DIVISION CODING STRUCTURE
+State Electoral Divisions are allocated a four digit code within each State or Territory. This is prefixed by a single digit State or Territory code to enable unique identification of States or Territories across the country.
+
+The codes used for the 2019 ASGS State Electoral Divisions may not match those used in 2018 as codes are assigned alphabetically within each State and Territory, and some State Electoral Division names have changed since 2018. A geographic correspondence file enabling the translation of data from 2018 to 2019 SEDs is available in the downloads tab of this publication.
+
+Special purpose codes are included as balancing items. SA1s allocated to these codes are not part of a State Electoral Division.
+
+SED code 9494 is reserved for those State or Territories where people are coded to the No Usual Address SA1s.
+SED code 9797 is reserved for those State or Territories that have Migratory, Off-Shore and Shipping SA1s.
+
+Example:
+State and Territory	State Electoral Division Code	State Electoral Division Name
+5	9494	No usual address (WA)
+5	9797	Migratory - Offshore - Shipping (WA)
+
+It should be noted that States or Territories have different electoral arrangements. A summary of these differences and how they affect the State Electoral Division classification is provided below.
+
+
+New South Wales (NSW)
+New South Wales has two Houses of Parliament but only the Legislative Assembly (Lower House) electoral districts are represented in the State Electoral Division classification since the Legislative Council (upper House) is a single constituency. State Electoral Divisions are sorted by Lower House district name and then allocated a State or Territory code (digit 1) and a code starting from 0001 (digits 2-5).
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+New South Wales	1	10001	Albury
+New South Wales	1	10002	Auburn
+
+
+
+Victoria (Vic.)
+In Victoria, the Legislative Council (Upper House) regions are obtained by amalgamating the Legislative Assembly (Lower House) electoral districts. The State Electoral Division classification provides information on both of these houses. The code comprises a State or Territory code (digit 1), a Lower House code (digits 2-3) and an Upper House code (digits 4-5). Upper House region names are recorded in brackets after the Lower House district names.
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Victoria	2	20106	Albert Park (Southern Metropolitan)
+Victoria	2	20207	Altona (Western Metropolitan)
+
+
+
+Queensland (Qld)
+Queensland has only one House of Parliament (the Legislative Assembly) with each member representing an electoral district. These districts are equivalent to divisions in this classification. State Electoral Divisions are sorted by name then allocated a State or Territory code (digit 1) and a code starting from 0001 (digits 2-5).
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Queensland	3	30001	Algester
+Queensland	3	30002	Aspley
+
+
+
+South Australia (SA)
+Like New South Wales, in South Australia, there are two Houses of Parliament but only the House of Assembly (Lower House) electoral districts are represented in the State Electoral Division classification since the Legislative Council (Upper House) is a single constituency. State Electoral Divisions are sorted by Lower House name then allocated a State or Territory code (digit 1) and a code starting from 0001 (digits 2-5).
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+South Australia	4	40001	Adelaide
+South Australia	4	40002	Badcoe
+
+
+
+Western Australia (WA)
+In Western Australia, Legislative Council (Upper House) regions are obtained by amalgamating the Legislative Assembly (Lower House) electoral districts. The State Electoral Division classification provides information on both of these houses. The five-digit code comprises a State or Territory code (digit 1), a Lower House code (digits 2-3) and an Upper House code (digits 4-5). Upper House region names are recorded in brackets after the Lower House district names.
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Western Australia	5	50106	Albany (South West)
+Western Australia	5	50304	Balcatta (North Metropolitan)
+
+
+
+Tasmania (Tas.)
+In Tasmania there are two Houses of Parliament, the House of Assembly (Lower House) and the Legislative Council (Upper House). The Upper House divisions do not aggregate to or from the Lower House divisions. Information on both Houses is provided by the State Electoral Division classification. The code comprises a State or Territory code (digit 1), a Lower House code (digits 2-3), and an Upper House code (digits 4-5). Tasmanian Upper House names are recorded in brackets after Lower House names. Because Upper House divisions do not aggregate from the Lower House divisions there is more than one code covering a Lower House division, for example, one for each overlapping House division.
+
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Tasmania	6	60301	Clark (Derwent)
+Tasmania	6	60302	Clark (Elwick)
+Tasmania	6	60303	Clark (Hobart)
+Tasmania	6	60310	Clark (Nelson)
+Tasmania	6	60404	Franklin (Huon)
+Tasmania	6	60410	Franklin (Nelson)
+Tasmania	6	60411	Franklin (Pembroke)
+Tasmania	6	60414	Franklin (Rumney)
+
+
+
+Northern Territory (NT)
+In the Northern Territory there is only one House of Parliament, the Legislative Assembly, the electorates for which are equivalent to the divisions in the State Electoral Division classification. State Electoral Divisions are sorted by name, then allocated a State or Territory code (digit 1), and then a code starting from 0001 (digits 2-5).
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Northern Territory	7	70001	Arafura
+Northern Territory	7	70002	Araluen
+
+
+
+Australian Capital Territory (ACT)
+The Australian Capital Territory has only one House of Parliament, the Legislative Assembly, the electorates for which are equivalent to the divisions in the State Electoral Division classification. State Electoral Divisions are sorted by name and then allocated State or Territory code (digit 1), and then a code starting from 0001 (digits 2-5).
+
+Example:
+State and Territory Name	State and Territory Code	State Electoral Division Code	State Electoral Division Name
+Australian Capital Territory	8	80001	Brindabella
+Australian Capital Territory	8	80002	Ginninderra
+
+
+
+Other Territories (OT)
+There are no State Electoral boundaries for Other Territories.
+State and Territory Code	State Electoral Division Code	State Electoral Division Name
+9	99191	Unclassified (OT)
+
+This""" ;
+  rdfs:label "sedCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "5"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -2571,6 +3464,80 @@ This""" ;
         ) ;
     ] ;
 .
+asgs-id:sosCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
+  rdfs:comment """SOS CODING STRUCTURE
+
+A SOS is identifiable by a 2 digit fully hierarchical code. These are outlined in the examples below.
+
+The SOS code comprises a State or Territory (S/T) and SOS identifier. A SOS identifier is only unique if it is preceded by the State or Territory identifier.
+
+
+For example Major Urban in Victoria:
+
+
+20 Major Urban
+S/T	
+SOS identifier
+SOS Name
+2	
+0
+Major Urban
+
+
+For example Rural Balance in Western Australia:
+
+53 Rural Balance
+S/T	
+SOS identifier
+SOS Name
+5	
+3
+Rural Balance
+
+SOS Special Purpose Codes
+
+Two SOS are defined in each State or Territory for that part of a population which cannot be meaningfully assigned to a geographically defined region:
+· Migratory – Offshore – Shipping
+· No usual address
+
+
+For example Migratory – Offshore – Shipping in Tasmania:
+
+67 Migratory – Offshore – Shipping (Tas.)
+S/T	
+SOS identifier
+SOS Name
+6	
+7
+Migratory – Offshore – Shipping (Tas.)
+
+
+For example No usual address in New South Wales:
+
+19 No usual address (NSW)
+S/T	
+SOS identifier
+SOS Name
+1	
+9
+No usual address (NSW)
+""" ;
+  rdfs:label "sosCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "2"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sosCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
@@ -2719,6 +3686,24 @@ No usual address (NSW)
         ) ;
     ] ;
 .
+asgs-id:sosName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
+  rdfs:comment """SOS AND SOSR NAMES
+
+Section of State (SOS) and Section of State Range (SOSR) names are not unique in Australia.
+""" ;
+  rdfs:label "sosName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sosName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
@@ -2751,6 +3736,87 @@ Section of State (SOS) and Section of State Range (SOSR) names are not unique in
       owl:withRestrictions (
           [
             xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:sosrCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
+  rdfs:comment """SOSR CODING STRUCTURE
+
+A SOSR is identifiable by a 3 digit fully hierarchical code. This comprises State or Territory, SOS and SOSR identifiers. A SOSR identifier is only unique if it is preceded by the State or Territory and SOS identifiers. See ‘Design of SOS and SOSR’ for the SOS and SOSR identifiers used for the different SOSR population ranges.
+
+The examples below show how the SOSR codes are assigned to the SOSR Name.
+
+
+For example SOSR of ‘1 million or more’ in Western Australia:
+
+501 ‘1 million or more’
+S/T	
+SOS
+SOSR
+SOSR Name
+5	
+0
+1
+1 million or more
+
+
+For example SOSR of ‘Remainder of State/Territory’ in South Australia:
+
+431 Remainder of State/Territory
+S/T	
+SOS
+SOSR
+SOSR Name
+4	
+3
+1
+Remainder of State / Territory
+
+
+SOSR Special Purpose Codes
+
+Two SOSR are defined in each State or Territory for that part of a population which cannot be meaningfully assigned to a geographically defined region:
+· Migratory – Offshore – Shipping
+· No usual address
+
+
+For example Migratory – Offshore – Shipping in Queensland:
+
+379 Migratory – Offshore – Shipping (Qld)
+S/T	
+SOS
+SOSR
+SOSR Name
+3	
+7
+9
+Migratory – Offshore – Shipping (Qld)
+
+
+For example No usual address in the Australian Capital Territory:
+
+899 No usual address (ACT)
+S/T	
+SOS
+SOSR
+SOSR Name
+8	
+9
+9
+No usual address (ACT)""" ;
+  rdfs:label "sosrCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "3"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -2917,6 +3983,24 @@ No usual address (ACT)""" ;
         ) ;
     ] ;
 .
+asgs-id:sosrName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
+  rdfs:comment """SOS AND SOSR NAMES
+
+Section of State (SOS) and Section of State Range (SOSR) names are not unique in Australia.
+""" ;
+  rdfs:label "sosrName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "50"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sosrName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SOS%20and%20SOSR%20Name%20and%20Coding%20Structure~14> ;
@@ -2953,6 +4037,20 @@ Section of State (SOS) and Section of State Range (SOSR) names are not unique in
         ) ;
     ] ;
 .
+asgs-id:sscCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "sscCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sscCode2016
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -2967,6 +4065,20 @@ asgs-id:sscCode2016
         ) ;
     ] ;
 .
+asgs-id:sscName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "sscName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:sscName2016
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -2977,6 +4089,33 @@ asgs-id:sscName2016
       owl:withRestrictions (
           [
             xsd:maxLength 100 ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:stateCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Australia%20(AUS)%20and%20State%20%7C%20Territory%20(S%7CT)~10017> ;
+  rdfs:comment """States and Territories are identified by unique one-digit codes within Australia as follows:
+State and Territory Codes and Names
+Code	S/T
+
+1	New South Wales
+2	Victoria
+3	Queensland
+4	South Australia
+5	Western Australia
+6	Tasmania
+7	Northern Territory
+8	Australian Capital Territory
+9	Other Territories""" ;
+  rdfs:label "stateCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[1-9]" ;
           ]
         ) ;
     ] ;
@@ -3035,6 +4174,25 @@ Code	S/T
         ) ;
     ] ;
 .
+asgs-id:stateName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Australia%20(AUS)%20and%20State%20%7C%20Territory%20(S%7CT)~10017> ;
+  rdfs:label "stateName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "New South Wales"
+          "Victoria"
+          "Queensland"
+          "South Australia"
+          "Western Australia"
+          "Tasmania"
+          "Northern Territory"
+          "Australian Capital Territory"
+          "Other Territories"
+        ) ;
+    ] ;
+.
 asgs-id:stateName2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Australia%20(AUS)%20and%20State%20%7C%20Territory%20(S%7CT)~10017> ;
@@ -3074,6 +4232,33 @@ asgs-id:stateName2016
     ] ;
 .
 asgs-id:stateOrTerritory1DigitCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Australia%20(AUS)%20and%20State%20%7C%20Territory%20(S%7CT)~10017> ;
+  rdfs:comment """States and Territories are identified by unique one-digit codes within Australia as follows:
+State and Territory Codes and Names
+Code	S/T
+
+1	New South Wales
+2	Victoria
+3	Queensland
+4	South Australia
+5	Western Australia
+6	Tasmania
+7	Northern Territory
+8	Australian Capital Territory
+9	Other Territories""" ;
+  rdfs:label "stateOrTerritory1DigitCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[1-9]" ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:stateOrTerritory1DigitCode_1
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.001~July%202016~Main%20Features~Australia%20(AUS)%20and%20State%20%7C%20Territory%20(S%7CT)~10017> ;
   rdfs:comment """States and Territories are identified by unique one-digit codes within Australia as follows:
@@ -3269,6 +4454,43 @@ Within each State and Territory, the SA4 identifier is in the range 01- 79. SA4 
         ) ;
     ] ;
 .
+asgs-id:suaCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SUA%20Coding%20Structure~18> ;
+  rdfs:comment """SUA CODING STRUCTURE
+
+A Significant Urban Area (SUA) is identifiable by a unique 4 digit non-hierarchical code, with the first digit identifying the State or Territory (S/T). Those SUAs which cross state boundaries are given the State or Territory identifier for the State or Territory which contains the largest Centre. The regions representing those parts of a State or Territory 'Not in a significant urban area' have codes ending in 000.
+
+The codes used for the 2016 SUAs may not match those used in 2011 as codes are assigned alphabetically within each State or Territory for each Australian Statistical Geography Standard (ASGS) edition, and SUA names may have change since 2011.
+
+For example:
+
+S/T identifier	
+SUA identifier
+SUA Name
+5	
+009
+Perth
+3	
+006
+Gold Coast - Tweed Heads
+8	
+000
+Not in a Significant Urban Area (ACT)""" ;
+  rdfs:label "suaCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "4"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:suaCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SUA%20Coding%20Structure~18> ;
@@ -3339,6 +4561,45 @@ Not in a Significant Urban Area (ACT)""" ;
           ]
           [
             xsd:length "4"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:suaName
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~SUA%20Names~17> ;
+  rdfs:comment """SUA NAMES
+
+Key criteria for the Significant Urban Area (SUA) names are that they be:
+· meaningful
+· max of 40 characters
+· must be unique within Australia.
+
+A single Statistical Area Level 2 (SA2) SUA will be named after the Urban Centre:
+· Alice Springs
+· Albany
+· Mount Gambier
+
+A multiple SA2 SUA will be named after the largest Urban Centre it contains:
+· Toowoomba
+
+Where a SUA represents a combination of two centres of comparable importance, it is named for both:
+· Gladstone – Tannum Sands
+· Kalgoorlie – Boulder
+
+Where a SUA cross a State or Territory (S/T) border, it is named after the largest centre on each side:
+· Gold Coast – Tweed Heads
+· Canberra – Queanbeyan
+
+Where an SUA represents a region with a widely recognised name, it is named for that region:
+· Sunshine Coast""" ;
+  rdfs:label "suaName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "40"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -3421,6 +4682,20 @@ Where an SUA represents a region with a widely recognised name, it is named for 
         ) ;
     ] ;
 .
+asgs-id:trCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
+  rdfs:label "trCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
 asgs-id:trCode2011
   a rdfs:Datatype ;
   dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.003~July%202019~Main%20Features~Overview~1> ;
@@ -3445,6 +4720,88 @@ asgs-id:trCode2012
       owl:withRestrictions (
           [
             xsd:pattern "[0-9]+" ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:uclCode
+  a rdfs:Datatype ;
+  dcterms:source <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~UCL%20Coding%20Structure~11> ;
+  rdfs:comment """UCL CODING STRUCTURE
+
+An Urban Centre and Locality (UCL) is identifiable by a 6 digit fully hierarchical code. This comprises a State or Territory (S/T), Section of State (SOS), Section of State Range (SOSR) and an UCL identifier. An UCL identifier is only unique if it is preceded by the State or Territory, SOS and SOSR identifiers. It is therefore possible to identify the population range to which the UCL belongs from the component Section of State and Section of State Range codes. This was not possible under the old Australian Standard Geographical Classification (ASGC) UCL coding system.
+
+For example Jervis Bay (L) in Other Territories:
+
+922002 Jervis Bay (L)
+S/T	
+SOS
+SOSR
+UCL
+UCL Name
+9	
+2
+2
+002
+Jervis Bay (L)
+
+
+For example Remainder of State/ Territory in Tasmania:
+631777 Remainder of State/Territory (Tas.)
+S/T	
+SOS
+SOSR
+UCL
+UCL Name
+6	
+3
+1
+777
+Remainder of State/Territory (Tas.)
+
+
+UCL SPECIAL PURPOSE CODES
+
+Two UCLs are defined in each State or Territory for that part of a population which cannot be meaningfully assigned to a geographically defined region:
+· Migratory - Offshore - Shipping
+· No usual address
+
+For example Migratory – Offshore – Shipping in New South Wales:
+179997 Migratory – Offshore – Shipping
+S/T	
+SOS
+SOSR
+UCL
+UCL Name
+1	
+7
+9
+997
+Migratory – Offshore – Shipping (NSW)
+
+
+For example No usual address in Victoria:
+299994 No usual address (Vic.)
+S/T	
+SOS
+SOSR
+UCL
+UCL Name
+2	
+9
+9
+994
+No usual address (Vic.)""" ;
+  rdfs:label "uclCode" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:pattern "[0-9]+" ;
+          ]
+          [
+            xsd:length "6"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;
@@ -3618,6 +4975,61 @@ No usual address (Vic.)""" ;
           ]
           [
             xsd:length "6"^^xsd:nonNegativeInteger ;
+          ]
+        ) ;
+    ] ;
+.
+asgs-id:uclName
+  a rdfs:Datatype ;
+  dcterms: <https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/by%20Subject/1270.0.55.004~July%202016~Main%20Features~UCL%20Names~10> ;
+  rdfs:comment """UCL NAMES
+
+The key criteria for Urban Centre and Locality (UCL) names are that they be:
+· meaningful
+· have a maximum of 40 characters
+· unique, i.e. not shared by any other UCL in Australia.
+
+Where an UCL represents a single dominant centre then it is named for that centre:
+· Melbourne
+· Sydney
+· Townsville
+
+Where an UCL represents a combination of two centres of comparable importance, it is named for both centres separated by a hyphen, the largest taking precedence:
+· Shepparton - Mooroopna
+· Bushfield - Woodford (L)
+· Berrara - Cudmirrah (L)
+
+Where an UCL crosses a State/Territory (S/T) border, the component parts are identified in brackets:
+· Gold Coast - Tweed Heads (Gold Coast Part)
+· Gold Coast - Tweed Heads (Tweed Heads Part)
+· Canberra - Queanbeyan (Canberra Part)
+· Canberra - Queanbeyan (Queanbeyan Part)
+
+Where an UCL represents a region with a widely recognised name, then that name is used:
+· Sunshine Coast
+· Central Coast
+
+Urban Centre names will be unique within Australia. If there are two Urban Centres with the same name, the standard State/Territory abbreviation will be added in brackets:
+· Maitland (SA)
+· Maitland (NSW)
+· Mount Barker (SA)
+· Mount Barker (WA)
+· Richmond (L) (Tas.)
+· Richmond (L) (Qld)
+
+Localities have (L) appended to their names to indicate they are Localities and not Urban Centres:
+· Agnes Bank (L)
+· Avoca (L)
+· Mount Burr (L)
+
+In some cases Gazetted Localities and Aboriginal and Torres Strait Islander community names have been used to obtain UCL names.""" ;
+  rdfs:label "uclName" ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      owl:onDatatype xsd:string ;
+      owl:withRestrictions (
+          [
+            xsd:maxLength "40"^^xsd:nonNegativeInteger ;
           ]
         ) ;
     ] ;


### PR DESCRIPTION
Not clear that the datatypes for codes and names need to be time-stamped - version information is maintained elsewhere. 
The requirement for these datatypes is to (a) annotate the identifiers for disambiguation (b) document (and maybe enforce) some lexical patterns. 

This PR creates a set of date-independent datatypes. The date-stamped variants may be deprecated later. 